### PR TITLE
ZEN-16125 - Count received and rejected; Improve collision notices.

### DIFF
--- a/metric-consumer-app/src/main/etc/configuration.yaml
+++ b/metric-consumer-app/src/main/etc/configuration.yaml
@@ -22,8 +22,8 @@ metricService:
     perClientMaxBacklogSize: -1
     perClientMaxPercentOfFairBacklogSize: 100
     maxClientWaitTime: 10000
-    minTimeBetweenBroadcast: 50
-    minTimeBetweenNotification: 50
+    minTimeBetweenBroadcast: 500
+    minTimeBetweenNotification: 500
     tsdbWriterThreads: 1
     maxIdleTime: 10000
     maxConnectionBackOff: 5000

--- a/metric-consumer-app/src/main/etc/configuration.yaml
+++ b/metric-consumer-app/src/main/etc/configuration.yaml
@@ -21,7 +21,7 @@ metricService:
     lowCollisionMark: -1
     perClientMaxBacklogSize: -1
     perClientMaxPercentOfFairBacklogSize: 100
-    maxClientWaitTime: 10000
+    maxClientWaitTime: 60000
     minTimeBetweenBroadcast: 500
     minTimeBetweenNotification: 500
     tsdbWriterThreads: 1

--- a/metric-consumer-app/src/main/etc/configuration.yaml
+++ b/metric-consumer-app/src/main/etc/configuration.yaml
@@ -18,8 +18,12 @@ webSocketConfiguration:
 metricService:
     jobSize: 1000
     highCollisionMark: 200000
+    lowCollisionMark: -1
+    perClientMaxBacklogSize: -1
+    perClientMaxPercentOfFairBacklogSize: 100
     maxClientWaitTime: 10000
     minTimeBetweenBroadcast: 50
+    minTimeBetweenNotification: 50
     tsdbWriterThreads: 1
     maxIdleTime: 10000
     maxConnectionBackOff: 5000

--- a/metric-consumer-app/src/main/etc/configuration.yaml
+++ b/metric-consumer-app/src/main/etc/configuration.yaml
@@ -17,13 +17,13 @@ webSocketConfiguration:
 
 metricService:
     jobSize: 1000
-    highCollisionMark: 200000
-    lowCollisionMark: -1
+    highCollisionMark: 2000000
+    lowCollisionMark: 1000000
     perClientMaxBacklogSize: -1
     perClientMaxPercentOfFairBacklogSize: 100
     maxClientWaitTime: 60000
-    minTimeBetweenBroadcast: 500
-    minTimeBetweenNotification: 500
+    minTimeBetweenBroadcast: 100
+    minTimeBetweenNotification: 100
     tsdbWriterThreads: 1
     maxIdleTime: 10000
     maxConnectionBackOff: 5000

--- a/metric-consumer-app/src/main/etc/configuration.yaml
+++ b/metric-consumer-app/src/main/etc/configuration.yaml
@@ -19,7 +19,7 @@ metricService:
     jobSize: 1000
     highCollisionMark: 200000
     maxClientWaitTime: 10000
-    minTimeBetweenBroadcast: 500
+    minTimeBetweenBroadcast: 50
     tsdbWriterThreads: 1
     maxIdleTime: 10000
     maxConnectionBackOff: 5000

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricService.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricService.java
@@ -34,4 +34,19 @@ public interface MetricService {
      * @param received number of received metrics.
      */
     void incrementReceived(long received);
+
+    /**
+     *  Record a client collision notification was sent via websocket.
+     */
+    void incrementSentClientCollision();
+
+    /**
+     * Record a low collision event was broadcast via websocket.
+     */
+    void incrementBroadcastLowCollision();
+
+    /**
+     * Recored a high collision event was broadcast via websocket.
+     */
+    void incrementBroadcastHighCollision();
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricService.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricService.java
@@ -22,9 +22,16 @@ public interface MetricService {
      * Eagerly submit metrics to the tail of the queue until a high collision
      * is detected.
      *
-     * @param metrics metrics to be written to TSDB
+     * @param metrics metrics to be written to TSDB.
+     * @param clientId identifies which client the metrics came from
+     * @param onCollision callback in case of collision(s).
      * @return control message with result
      */
-    Control push(List<Metric> metrics, String clientId);
+    Control push(List<Metric> metrics, String clientId, Runnable onCollision);
 
+    /**
+     * Record a number of metrics were received (but not necessarily accepted/pushed).
+     * @param received number of received metrics.
+     */
+    void incrementReceived(long received);
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricServiceConfiguration.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricServiceConfiguration.java
@@ -359,9 +359,12 @@ public class MetricServiceConfiguration {
      * connected websocket clients. This prevents sending the same message
      * before a client can process the first message.
      *
-     * @param minTimeBetweenBroadcast milliseconds
+     * @param minTimeBetweenBroadcast milliseconds, must be less than 1000.
+     * @throws IllegalArgumentException if minTimeBetweenBroadcast greater than or equal to 1000.
      */
     public void setMinTimeBetweenBroadcast(int minTimeBetweenBroadcast) {
+        if (minTimeBetweenBroadcast >= 1000)
+            throw new IllegalArgumentException("minTimeBetweenBroadcast must be < 1000");
         this.minTimeBetweenBroadcast = minTimeBetweenBroadcast;
     }
 
@@ -370,9 +373,12 @@ public class MetricServiceConfiguration {
      * a specific websocket client. This prevents sending the same message
      * before a client can process the first message.
      *
-     * @param minTimeBetweenNotification milliseconds
+     * @param minTimeBetweenNotification milliseconds, must be less than 1000
+     * @throws IllegalArgumentException if minTimeBetweenNotification greater than or equal to 1000.
      */
     public void setMinTimeBetweenNotification(int minTimeBetweenNotification) {
+        if (minTimeBetweenNotification >= 1000)
+            throw new IllegalArgumentException("minTimeBetweenNotification must be < 1000");
         this.minTimeBetweenNotification = minTimeBetweenNotification;
     }
 

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/TsdbMetricsQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/TsdbMetricsQueue.java
@@ -33,7 +33,12 @@ public interface TsdbMetricsQueue {
      * @return zero, or a positive number if the queue contains any metrics with a matching tag.
      */
      long clientBacklogSize(String clientId);
-    
+
+    /**
+     * Count how many unique clients have we seen recently and/or currently have metrics in the queue?
+     */
+    long clientCount();
+
     /**
      * Retrieves and removes a number of elements from the queue. If there are
      * not enough elements in the queue to satisfy the request, then the entire

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/TsdbMetricsQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/TsdbMetricsQueue.java
@@ -76,4 +76,16 @@ public interface TsdbMetricsQueue {
      * @param size number of lost metrics.
      */
     void incrementLostMetrics(long size);
+
+    /**
+     * Record a number of metrics were received (but not necessarily accepted).
+     * @param received number of received metrics.
+     */
+    void incrementReceived(long received);
+
+    /**
+     * Record a number of metrics were rejected (after being received).
+     * @param rejected number of rejected metrics.
+     */
+    void incrementRejected(long rejected);
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/TsdbMetricsQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/TsdbMetricsQueue.java
@@ -88,4 +88,34 @@ public interface TsdbMetricsQueue {
      * @param rejected number of rejected metrics.
      */
     void incrementRejected(long rejected);
+
+    /**
+     * Record a high collision event.
+     */
+    void incrementHighCollision();
+
+    /**
+     * Record a low collision event.
+     */
+    void incrementLowCollision();
+
+    /**
+     * Record a client collision event.
+     */
+    void incrementClientCollision();
+
+    /**
+     *  Record a client collision notification was sent via websocket.
+     */
+    void incrementSentClientCollision();
+
+    /**
+     * Record a low collision event was broadcast via websocket.
+     */
+    void incrementBroadcastLowCollision();
+
+    /**
+     * Recored a high collision event was broadcast via websocket.
+     */
+    void incrementBroadcastHighCollision();
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/FakeTsdbWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/FakeTsdbWriter.java
@@ -14,6 +14,7 @@ import com.google.common.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -40,7 +41,7 @@ class FakeTsdbWriter extends OpenTsdbWriter {
             TsdbWriterRegistry registry,
             OpenTsdbClientPool clientPool,
             TsdbMetricsQueue metricsQueue,
-            EventBus eventBus) {
+            @Qualifier("zapp::event-bus::async") EventBus eventBus) {
         super(config, registry, clientPool, metricsQueue, eventBus);
     }
 

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/MetricServicePoster.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/MetricServicePoster.java
@@ -89,6 +89,8 @@ class MetricServicePoster implements MetricPoster {
         List<Metric> metrics = batch.getMetrics();
         log.debug("posting metric batch len(metrics): {}", metrics.size());
 
+        metricService.incrementReceived(metrics.size());
+
         if (configuration.isAuthEnabled()) {
             String tenantId = getTenantId();
             if (tenantId == null) {
@@ -98,7 +100,7 @@ class MetricServicePoster implements MetricPoster {
             Utils.injectTag("zenoss_tenant_id", tenantId, metrics);
         }
 
-        metricService.push(metrics, this.getClass().getCanonicalName());
+        metricService.push(metrics, this.getClass().getCanonicalName(), null);
     }
 
     @Override

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/MetricsQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/MetricsQueue.java
@@ -50,6 +50,12 @@ class MetricsQueue implements TsdbMetricsQueue {
         this.totalReceivedMetric = registerReceived();
         this.totalRejectedMetric = registerRejected();
         this.totalLostMetric = registerLost();
+        this.totalHighCollisionMetric = registerHighCollision();
+        this.totalLowCollisionMetric = registerLowCollision();
+        this.totalClientCollisionMetric = registerClientCollision();
+        this.totalBroadcastHighCollisionMetric = registerBroadcastHighCollision();
+        this.totalBroadcastLowCollisionMetric = registerBroadcastLowCollision();
+        this.totalSentClientCollisionMetric = registerSentClientCollision();
     }
 
     @Override
@@ -151,6 +157,36 @@ class MetricsQueue implements TsdbMetricsQueue {
         totalRejectedMetric.mark(rejected);
     }
 
+    @Override
+    public void incrementHighCollision() {
+        totalHighCollisionMetric.mark();
+    }
+
+    @Override
+    public void incrementLowCollision() {
+        totalLowCollisionMetric.mark();
+    }
+
+    @Override
+    public void incrementClientCollision() {
+        totalClientCollisionMetric.mark();
+    }
+
+    @Override
+    public void incrementSentClientCollision() {
+        totalSentClientCollisionMetric.mark();
+    }
+
+    @Override
+    public void incrementBroadcastLowCollision() {
+        totalBroadcastLowCollisionMetric.mark();
+    }
+
+    @Override
+    public void incrementBroadcastHighCollision() {
+        totalBroadcastHighCollisionMetric.mark();
+    }
+
 
     private Meter registerIncoming() {
         return Metrics.newMeter(incomingMetricName(), "metrics", TimeUnit.SECONDS);
@@ -172,6 +208,30 @@ class MetricsQueue implements TsdbMetricsQueue {
         return Metrics.newMeter(rejectedMetricName(), "metrics", TimeUnit.SECONDS);
     }
 
+    private Meter registerHighCollision() {
+        return Metrics.newMeter(highCollisionMetricName(), "metrics", TimeUnit.SECONDS);
+    }
+
+    private Meter registerLowCollision() {
+        return Metrics.newMeter(lowCollisionMetricName(), "metrics", TimeUnit.SECONDS);
+    }
+
+    private Meter registerClientCollision() {
+        return Metrics.newMeter(clientCollisionMetricName(), "metrics", TimeUnit.SECONDS);
+    }
+
+    private Meter registerBroadcastHighCollision() {
+        return Metrics.newMeter(broadcastHighCollisionMetricName(), "metrics", TimeUnit.SECONDS);
+    }
+
+    private Meter registerBroadcastLowCollision() {
+        return Metrics.newMeter(broadcastLowCollisionMetricName(), "metrics", TimeUnit.SECONDS);
+    }
+
+    private Meter registerSentClientCollision() {
+        return Metrics.newMeter(sentClientCollisionMetricName(), "metrics", TimeUnit.SECONDS);
+    }
+
     // Used for testing
     void resetMetrics() {
         totalErrorsMetric.clear();
@@ -181,9 +241,21 @@ class MetricsQueue implements TsdbMetricsQueue {
         registry.removeMetric(outgoingMetricName());
         registry.removeMetric(lostMetricName());
         registry.removeMetric(receivedMetricName());
+        registry.removeMetric(highCollisionMetricName());
+        registry.removeMetric(lowCollisionMetricName());
+        registry.removeMetric(clientCollisionMetricName());
+        registry.removeMetric(broadcastHighCollisionMetricName());
+        registry.removeMetric(broadcastLowCollisionMetricName());
+        registry.removeMetric(sentClientCollisionMetricName());
         totalIncomingMetric = registerIncoming();
         totalOutGoingMetric = registerOutgoing();
         totalLostMetric = registerLost();
+        totalHighCollisionMetric = registerHighCollision();
+        totalLowCollisionMetric = registerLowCollision();
+        totalClientCollisionMetric = registerClientCollision();
+        totalBroadcastHighCollisionMetric = registerBroadcastHighCollision();
+        totalBroadcastLowCollisionMetric = registerBroadcastLowCollision();
+        totalSentClientCollisionMetric = registerSentClientCollision();
     }
 
     @Override
@@ -240,6 +312,30 @@ class MetricsQueue implements TsdbMetricsQueue {
         return totalLostMetric.oneMinuteRate();
     }
 
+    double getOneMinuteHighCollision() {
+        return totalHighCollisionMetric.oneMinuteRate();
+    }
+
+    double getOneMinuteLowCollision() {
+        return totalLowCollisionMetric.oneMinuteRate();
+    }
+
+    double getOneMinuteClientCollision() {
+        return totalClientCollisionMetric.oneMinuteRate();
+    }
+
+    double getOneMinuteBroadcastHighCollision() {
+        return totalBroadcastHighCollisionMetric.oneMinuteRate();
+    }
+
+    double getOneMinuteBroadcastLowCollision() {
+        return totalBroadcastLowCollisionMetric.oneMinuteRate();
+    }
+
+    double getOneMinuteSentClientCollision() {
+        return totalSentClientCollisionMetric.oneMinuteRate();
+    }
+
     MetricName incomingMetricName() {
         return new MetricName(MetricsQueue.class, "totalIncoming");
     }
@@ -266,6 +362,30 @@ class MetricsQueue implements TsdbMetricsQueue {
 
     MetricName rejectedMetricName() {
         return new MetricName(MetricsQueue.class, "totalRejected");
+    }
+
+    MetricName highCollisionMetricName() {
+        return new MetricName(MetricsQueue.class, "totalHighCollision");
+    }
+
+    MetricName lowCollisionMetricName() {
+        return new MetricName(MetricsQueue.class, "totalLowCollision");
+    }
+
+    MetricName clientCollisionMetricName() {
+        return new MetricName(MetricsQueue.class, "totalClientCollision");
+    }
+
+    MetricName broadcastHighCollisionMetricName() {
+        return new MetricName(MetricsQueue.class, "totalBroadcastHighCollision");
+    }
+
+    MetricName broadcastLowCollisionMetricName() {
+        return new MetricName(MetricsQueue.class, "totalBroadcastLowCollision");
+    }
+
+    MetricName sentClientCollisionMetricName() {
+        return new MetricName(MetricsQueue.class, "totalSentClientCollision");
     }
 
     private static final Logger log = LoggerFactory.getLogger(MetricsQueue.class);
@@ -321,4 +441,35 @@ class MetricsQueue implements TsdbMetricsQueue {
      * How many metrics were received but rejected
      */
     private Meter totalRejectedMetric;
+
+    /**
+     * How many high collision events?
+     */
+    private Meter totalHighCollisionMetric;
+
+    /**
+     * How many low collision events?
+     */
+    private Meter totalLowCollisionMetric;
+
+    /**
+     * How many client collision events?
+     */
+    private Meter totalClientCollisionMetric;
+
+    /**
+     * How many high collision events were broadcast?
+     */
+    private Meter totalBroadcastHighCollisionMetric;
+
+    /**
+     * How many low collision events were broadcast?
+     */
+    private Meter totalBroadcastLowCollisionMetric;
+
+    /**
+     * How many client collision events were sent via websocket?
+     */
+    private Meter totalSentClientCollisionMetric;
+
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/MetricsQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/MetricsQueue.java
@@ -67,7 +67,7 @@ class MetricsQueue implements TsdbMetricsQueue {
         this.totalBroadcastHighCollisionMetric = registerBroadcastHighCollision();
         this.totalBroadcastLowCollisionMetric = registerBroadcastLowCollision();
         this.totalSentClientCollisionMetric = registerSentClientCollision();
-        this.recentClientIds = CacheBuilder.newBuilder().expireAfterAccess(600, TimeUnit.SECONDS).build(CacheLoader.from(YEPYEP));
+        this.recentClientIds = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build(CacheLoader.from(YEPYEP));
     }
 
     @Override

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebResource.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebResource.java
@@ -68,6 +68,9 @@ public class MetricWebResource {
         List<Metric> metrics = metricCollection.getMetrics();
         log.debug("POST: metrics/store:  len(metrics)={}", (metrics == null) ? -1 : metrics.size());
 
+        if (metrics != null) {
+            metricService.incrementReceived(metrics.size());
+        }
         //tag metrics with http parameters
         log.debug( "Tagging metrics with http parameter prefixes: {}", configuration.getHttpParameterTags());
         Utils.tagMetrics(request, metrics, configuration.getHttpParameterTags());
@@ -85,6 +88,6 @@ public class MetricWebResource {
         Utils.filterMetricTags( metrics, configuration.getTagWhiteList());
 
         String remoteIp = Utils.remoteAddress(request);
-        return metricService.push(metrics, remoteIp);
+        return metricService.push(metrics, remoteIp, null);
     }
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
@@ -61,7 +61,7 @@ public class MetricWebSocket {
             .build(CacheLoader.from(new Supplier<String>() {
                 @Override
                 public String get() {
-                    return Long.toString(sequence.incrementAndGet(),10);
+                    return String.format("websocket%d",sequence.incrementAndGet());
                 }
             }));
 
@@ -74,6 +74,7 @@ public class MetricWebSocket {
         this.eventBus = eventBus;
         this.configuration = configuration;
         this.minTimeBetweenBroadcast = configuration.getMetricServiceConfiguration().getMinTimeBetweenBroadcast();
+        this.minTimeBetweenNotification = configuration.getMetricServiceConfiguration().getMinTimeBetweenNotification();
         this.lastHighCollisionBroadcast = new AtomicLong();
         this.lastLowCollisionBroadcast = new AtomicLong();
         this.lastDropNotification = new AtomicLong();
@@ -187,7 +188,7 @@ public class MetricWebSocket {
         // We send at most every X milliseconds. Check the LOW time.
         long now = System.currentTimeMillis();
         long lastCheckTimeExpected = lastDropNotification.get();
-        if (now > lastCheckTimeExpected + minTimeBetweenBroadcast &&
+        if (now > lastCheckTimeExpected + minTimeBetweenNotification &&
                 lastDropNotification.compareAndSet(lastCheckTimeExpected, now)) {
             try {
                 String message = WebSocketBroadcast.newMessage(getClass(), event).asString();
@@ -240,6 +241,11 @@ public class MetricWebSocket {
      * How frequently should we broadcast collision messages?
      */
     private final int minTimeBetweenBroadcast;
+
+    /**
+     * How frequently should we send client-specific collision messages?
+     */
+    private final int minTimeBetweenNotification;
 
     /**
      * Last timestamp when we broadcast a low collision message

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
@@ -11,6 +11,10 @@
 package org.zenoss.app.consumer.metric.remote;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Supplier;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import org.apache.shiro.subject.Subject;
@@ -37,6 +41,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Path;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 @WebSocketListener(name = "metrics/store")
@@ -48,6 +53,17 @@ public class MetricWebSocket {
     private ConsumerAppConfiguration configuration;
 
     private final WeakHashMap<WebSocket.Connection, BinaryDecoder> decoders = new WeakHashMap<>();
+    private final AtomicLong sequence = new AtomicLong();
+    private final LoadingCache<WebSocket.Connection, String> connectionIds = CacheBuilder
+            .newBuilder()
+            .expireAfterAccess(1, TimeUnit.HOURS)
+            .weakKeys()
+            .build(CacheLoader.from(new Supplier<String>() {
+                @Override
+                public String get() {
+                    return Long.toString(sequence.incrementAndGet(),10);
+                }
+            }));
 
     @Autowired
     public MetricWebSocket(
@@ -60,6 +76,7 @@ public class MetricWebSocket {
         this.minTimeBetweenBroadcast = configuration.getMetricServiceConfiguration().getMinTimeBetweenBroadcast();
         this.lastHighCollisionBroadcast = new AtomicLong();
         this.lastLowCollisionBroadcast = new AtomicLong();
+        this.lastDropNotification = new AtomicLong();
     }
 
     @PostConstruct
@@ -74,53 +91,68 @@ public class MetricWebSocket {
 
     @OnMessage
     public Control onMessage(byte[] data, WebSocketSession session) {
-        BinaryDecoder decoder = decoders.get(session.getConnection());
-        if (decoder == null) {
-            decoder = new BinaryDecoder();
-            decoders.put(session.getConnection(), decoder);
-        }
         try {
-            return onMessage(decoder.decode(data), session);
-        } catch (IOException e) {
-            log.error("Invalid message");
-            return null;
+            BinaryDecoder decoder = decoders.get(session.getConnection());
+            if (decoder == null) {
+                decoder = new BinaryDecoder();
+                decoders.put(session.getConnection(), decoder);
+            }
+            try {
+                return onMessage(decoder.decode(data), session);
+            } catch (IOException e) {
+                log.error("Invalid message");
+                return Control.malformedRequest("Invalid message");
+            }
+        } catch (RuntimeException e) {
+            log.error("Unexpected exception: " + e.getMessage(), e);
+            return Control.error(e.getMessage());
         }
     }
 
+    private String getClientId(WebSocketSession session) {
+        return connectionIds.getUnchecked(session.getConnection());
+    }
+
     @OnMessage
-    public Control onMessage(Message message, WebSocketSession session) {
-        Metric[] metrics = message.getMetrics();
-        int metricsLength = (metrics == null) ? -1 : metrics.length;
-        log.debug("Message(control={}, len(metrics)={}) - START", message.getControl(), metricsLength);
+    public Control onMessage(Message message, final WebSocketSession session) {
+        try {
+            Metric[] metrics = message.getMetrics();
+            int metricsLength = (metrics == null) ? -1 : metrics.length;
+            log.debug("Message(control={}, len(metrics)={}) - START", message.getControl(), metricsLength);
 
-        //process metrics
-        if (metrics != null) {
-            log.debug( "Tagging metrics with parameters: {}", configuration.getHttpParameterTags());
-            HttpServletRequest request = session.getHttpServletRequest();
+            //process metrics
+            if (metrics != null) {
+                service.incrementReceived(metrics.length);
+                log.debug( "Tagging metrics with parameters: {}", configuration.getHttpParameterTags());
+                HttpServletRequest request = session.getHttpServletRequest();
 
-            //tag metrics using configured http parameters
-            List<Metric> metricList = Arrays.asList(metrics);
-            Utils.tagMetrics(request, metricList, configuration.getHttpParameterTags());
+                //tag metrics using configured http parameters
+                List<Metric> metricList = Arrays.asList(metrics);
+                Utils.tagMetrics(request, metricList, configuration.getHttpParameterTags());
 
-            //tag metrics with tenant id (obviously, tenant-id's identified through authentication)
-            if (configuration.isAuthEnabled()) {
-                Subject subject = session.getSubject();
-                ZenossTenant tenant = subject.getPrincipals().oneByType(ZenossTenant.class);
+                //tag metrics with tenant id (obviously, tenant-id's identified through authentication)
+                if (configuration.isAuthEnabled()) {
+                    Subject subject = session.getSubject();
+                    ZenossTenant tenant = subject.getPrincipals().oneByType(ZenossTenant.class);
 
-                log.debug("Tagging metrics with tenant_id: {}", tenant.id());
-                Utils.injectTag("zenoss_tenant_id", tenant.id(), metricList);
+                    log.debug("Tagging metrics with tenant_id: {}", tenant.id());
+                    Utils.injectTag("zenoss_tenant_id", tenant.id(), metricList);
+                }
+
+                //filter tags using configuration white list
+                Utils.filterMetricTags( metricList, configuration.getTagWhiteList());
+
+                //enqueue metrics for transfer
+                final String clientId = getClientId(session);
+                Control control = service.push(metricList, clientId, onCollision(clientId, session));
+                log.debug("Message(control={}, len(metrics)={}) -> {}", message.getControl(), metricsLength, control);
+                return control;
+            } else {
+                return Control.malformedRequest("Null metrics not accepted");
             }
-
-            //filter tags using configuration white list
-            Utils.filterMetricTags( metricList, configuration.getTagWhiteList());
-
-            //enqueue metrics for transfer
-            String remoteIp = Utils.remoteAddress(request);
-            Control control = service.push(metricList, remoteIp);
-            log.debug("Message(control={}, len(metrics)={}) -> {}", message.getControl(), metricsLength, control);
-            return control;
-        } else {
-            return Control.malformedRequest("Null metrics not accepted");
+        } catch (RuntimeException e) {
+            log.error("Unexpected exception: " + e.getMessage(), e);
+            return Control.error(e.getMessage());
         }
     }
 
@@ -139,6 +171,30 @@ public class MetricWebSocket {
                 break;
 
             default:
+        }
+    }
+
+    Runnable onCollision(final String clientId, final WebSocketSession session) {
+        return new Runnable(){
+            @Override
+            public void run() {
+                clientCollisionNotification(Control.clientCollision(clientId), session);
+            }
+        };
+    }
+
+    void clientCollisionNotification(Control event, WebSocketSession session) {
+        // We send at most every X milliseconds. Check the LOW time.
+        long now = System.currentTimeMillis();
+        long lastCheckTimeExpected = lastDropNotification.get();
+        if (now > lastCheckTimeExpected + minTimeBetweenBroadcast &&
+                lastDropNotification.compareAndSet(lastCheckTimeExpected, now)) {
+            try {
+                String message = WebSocketBroadcast.newMessage(getClass(), event).asString();
+                session.sendMessage(message);
+            } catch (IOException e) {
+                log.warn("Failed to send dropped-message notification to client: {}", e.getMessage());
+            }
         }
     }
 
@@ -191,4 +247,9 @@ public class MetricWebSocket {
      * Last timestamp when we broadcast a high collision message
      */
     private final AtomicLong lastHighCollisionBroadcast;
+
+    /**
+     * Last timestamp when we sent a dropped-metrics message
+     */
+    private final AtomicLong lastDropNotification;
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
@@ -54,9 +54,9 @@ public class MetricWebSocket {
 
     private final WeakHashMap<WebSocket.Connection, BinaryDecoder> decoders = new WeakHashMap<>();
     private final AtomicLong sequence = new AtomicLong();
-    private final LoadingCache<WebSocket.Connection, String> connectionIds = CacheBuilder
+    private final LoadingCache<WebSocketSession, String> connectionIds = CacheBuilder
             .newBuilder()
-            .expireAfterAccess(1, TimeUnit.HOURS)
+            .expireAfterAccess(6, TimeUnit.MINUTES)
             .weakKeys()
             .build(CacheLoader.from(new Supplier<String>() {
                 @Override
@@ -111,7 +111,7 @@ public class MetricWebSocket {
     }
 
     private String getClientId(WebSocketSession session) {
-        return connectionIds.getUnchecked(session.getConnection());
+        return connectionIds.getUnchecked(session);
     }
 
     @OnMessage

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/MetricWebSocket.java
@@ -192,8 +192,9 @@ public class MetricWebSocket {
             try {
                 String message = WebSocketBroadcast.newMessage(getClass(), event).asString();
                 session.sendMessage(message);
+                service.incrementSentClientCollision();
             } catch (IOException e) {
-                log.warn("Failed to send dropped-message notification to client: {}", e.getMessage());
+                log.warn("Failed to send collision notification to client: {}", e.getMessage());
             }
         }
     }
@@ -207,6 +208,7 @@ public class MetricWebSocket {
             try {
                 WebSocketBroadcast.Message message = WebSocketBroadcast.newMessage(getClass(), event);
                 eventBus.post(message);
+                service.incrementBroadcastLowCollision();
                 log.info("Sent low collision broadcast");
             } catch (JsonProcessingException ex) {
                 log.error("Unable to convert control message", ex);
@@ -224,6 +226,7 @@ public class MetricWebSocket {
                 WebSocketBroadcast.Message message = WebSocketBroadcast.newMessage(getClass(), event);
                 eventBus.post(message);
                 log.warn("Sent high collision broadcast");
+                service.incrementBroadcastHighCollision();
             } catch (JsonProcessingException ex) {
                 log.error("Unable to convert control message", ex);
             }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/Utils.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/remote/Utils.java
@@ -12,6 +12,8 @@ package org.zenoss.app.consumer.metric.remote;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zenoss.app.consumer.ConsumerAppConfiguration;
 import org.zenoss.app.consumer.metric.data.Metric;
 
@@ -26,12 +28,23 @@ import java.util.Map;
  */
 public final class Utils {
 
+    private static final Logger log = LoggerFactory.getLogger(Utils.class);
+
     /**
      * Best guess at the IP address of the remote end of the request.
      */
     public static String remoteAddress(HttpServletRequest request) {
         String forwardedFor = request.getHeader("X-Forwarded-For");
-        return (forwardedFor != null) ? forwardedFor : request.getRemoteAddr();
+        if (forwardedFor != null) {
+            log.debug("X-Forwarded-For: {}", forwardedFor);
+            return forwardedFor;
+        }
+        String xZAuthToken = request.getHeader("X-ZAuth-Token");
+        if (xZAuthToken != null) {
+            log.debug("X-ZAuth-Token: {}", xZAuthToken);
+            return xZAuthToken;
+        }
+        return request.getRemoteAddr();
     }
 
     /**

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/MetricServicePosterTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/MetricServicePosterTest.java
@@ -101,7 +101,7 @@ public class MetricServicePosterTest {
         batch.addMetric(metric);
 
         poster.post(batch);
-        verify(service).push( batch.getMetrics(), MetricServicePoster.class.getCanonicalName());
+        verify(service).push( batch.getMetrics(), MetricServicePoster.class.getCanonicalName(), null);
         assertEquals( "a-value", poster.getTenantId());
     }
 }

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricServiceTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricServiceTest.java
@@ -47,8 +47,8 @@ public class OpenTsdbMetricServiceTest {
     public void testPushHandlesNull() throws Exception {
         List<Metric> metrics  = Collections.singletonList(new Metric("name", 0, 0.0));
         OpenTsdbMetricService service = newService();
-        assertEquals(Control.malformedRequest("metrics not nullable"), service.push(null, "test"));
-        assertEquals(Control.malformedRequest("clientId not nullable"), service.push(metrics, null));
+        assertEquals(Control.malformedRequest("metrics not nullable"), service.push(null, "test", null));
+        assertEquals(Control.malformedRequest("clientId not nullable"), service.push(metrics, null, null));
     }
 
     @Test
@@ -56,7 +56,7 @@ public class OpenTsdbMetricServiceTest {
         Metric metric = new Metric("name", 0, 0.0);
         List<Metric> metrics  = Collections.singletonList(metric);
         OpenTsdbMetricService service = newService();
-        assertEquals(Control.ok(), service.push(metrics, "test"));
+        assertEquals(Control.ok(), service.push(metrics, "test", null));
         verify(metricsQueue, times(1)).addAll(metrics, "test");
     }
 
@@ -66,7 +66,7 @@ public class OpenTsdbMetricServiceTest {
         List<Metric> metrics  = Collections.singletonList(metric);
         config.setJobSize(Integer.MAX_VALUE);
         OpenTsdbMetricService service = newService();
-        assertEquals(Control.ok(), service.push(metrics, "test"));
+        assertEquals(Control.ok(), service.push(metrics, "test", null));
         verify(metricsQueue, times(1)).addAll(metrics, "test");
     }
 
@@ -79,7 +79,7 @@ public class OpenTsdbMetricServiceTest {
         when(metricsQueue.getTotalInFlight()).thenReturn(2L);
         
         OpenTsdbMetricService service = newService();
-        assertEquals(Control.ok(), service.push(metrics,"test"));
+        assertEquals(Control.ok(), service.push(metrics,"test", null));
         
         verify(metricsQueue, times(1)).addAll(metrics, "test");
         verify(eventBus, times(1)).post(Control.lowCollision());
@@ -95,7 +95,7 @@ public class OpenTsdbMetricServiceTest {
         when(metricsQueue.getTotalInFlight()).thenReturn(3L);
         
         OpenTsdbMetricService service = newService();
-        assertEquals(Control.dropped("collision detected"), service.push(metricList,"test"));
+        assertEquals(Control.dropped("consumer is overwhelmed"), service.push(metricList,"test", null));
         
         verify(metricsQueue, never()).addAll(metricList, "test");
         verify(eventBus, atLeastOnce()).post(Control.highCollision());

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebResourceTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebResourceTest.java
@@ -48,7 +48,7 @@ public class MetricWebResourceTest {
     public void setUp() throws Exception {
         List<String> parameters = Lists.newArrayList();
         configuration.setHttpParameterTags(parameters);
-        when(service.push(anyListOf(Metric.class), anyString())).thenReturn(control);
+        when(service.push(anyListOf(Metric.class), anyString(), any(Runnable.class))).thenReturn(control);
 
         request = mock(HttpServletRequest.class);
         subject = mock(Subject.class);
@@ -68,7 +68,7 @@ public class MetricWebResourceTest {
         when(request.getHeader("X-Forwarded-For")).thenReturn("test");
 
         assertThat(resource.post(mc, request)).isEqualTo(control);
-        verify(service).push(mc.getMetrics(), "test");
+        verify(service).push(mc.getMetrics(), "test", null);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class MetricWebResourceTest {
         tags.put("controlplane_tenant_id", "1");
         tags.put("controlplane_service_id", "2");
         Metric expected_metric = new Metric("name", 0, 1.0, tags);
-        verify(service).push(Lists.newArrayList(expected_metric), "test");
+        verify(service).push(Lists.newArrayList(expected_metric), "test", null);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class MetricWebResourceTest {
         tags = Maps.newHashMap();
         tags.put("zenoss_tenant_id", "tenant");
         Metric expected_metric = new Metric("name", 0, 1.0, tags);
-        verify(service).push(Lists.newArrayList(expected_metric), "test");
+        verify(service).push(Lists.newArrayList(expected_metric), "test", null);
     }
 
     @Test
@@ -144,6 +144,6 @@ public class MetricWebResourceTest {
         tags = Maps.newHashMap();
         tags.put("zenoss_tenant_id", "tenant");
         Metric expected_metric = new Metric("name", 0, 1.0, tags);
-        verify(service).push(Lists.newArrayList(expected_metric), "test");
+        verify(service).push(Lists.newArrayList(expected_metric), "test", null);
     }
 }

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
@@ -36,8 +36,8 @@ import static org.mockito.Mockito.*;
 
 public class MetricWebSocketTest {
 
-    private static final int TIME_BETWEEN_BROADCAST = 1000;
-    private static final int TIME_BETWEEN_NOTIFICATION = 1000;
+    private static final int TIME_BETWEEN_BROADCAST = 500;
+    private static final int TIME_BETWEEN_NOTIFICATION = 500;
 
     Subject subject;
     EventBus eventBus;

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
@@ -57,13 +57,12 @@ public class MetricWebSocketTest {
     @Test
     public void testOnMessage() throws Exception {
         MetricWebSocket socket = new MetricWebSocket(config(false), service, eventBus);
-        when(service.push(anyListOf(Metric.class), anyString())).thenReturn(new Control());
-        when(request.getHeader("X-Forwarded-For")).thenReturn("test");
+        when(service.push(anyListOf(Metric.class), anyString(), any(Runnable.class))).thenReturn(new Control());
         Metric metric = new Metric("name", 0, 0.0);
         Control control = new Control();
         Message message = new Message(control, new Metric[]{metric});
         assertEquals(new Control(), socket.onMessage(message, new WebSocketSession(subject, request, connection)));
-        verify(service).push(Collections.singletonList(metric),"test");
+        verify(service).push(eq(Collections.singletonList(metric)), eq("1"), any(Runnable.class));
     }
 
     @Test
@@ -76,11 +75,10 @@ public class MetricWebSocketTest {
         prefixes.add("controlplane");
         MetricWebSocket socket = new MetricWebSocket(config(prefixes, null, true), service, eventBus);
 
-        when(service.push(anyListOf(Metric.class),anyString())).thenReturn(new Control());
+        when(service.push(anyListOf(Metric.class),anyString(),any(Runnable.class))).thenReturn(new Control());
         when(request.getParameterNames()).thenReturn(Collections.enumeration(parameters));
         when(request.getParameter("controlplane_tenant_id")).thenReturn("1");
         when(request.getParameter("controlplane_service_id")).thenReturn("2");
-        when(request.getHeader("X-Forwarded-For")).thenReturn("test");
 
         PrincipalCollection principles = mock(PrincipalCollection.class);
         when(subject.getPrincipals()).thenReturn(principles);
@@ -96,7 +94,7 @@ public class MetricWebSocketTest {
         expected_metric.addTag("controlplane_tenant_id", "1");
         expected_metric.addTag("controlplane_service_id", "2");
         expected_metric.addTag("zenoss_tenant_id", "3");
-        verify(service).push(Collections.singletonList(expected_metric),"test");
+        verify(service).push(eq(Collections.singletonList(expected_metric)), eq("1"), any(Runnable.class));
     }
 
     @Test
@@ -113,11 +111,10 @@ public class MetricWebSocketTest {
         List<String> parameters = Lists.newArrayList();
         parameters.add( "controlplane_tenant_id");
         parameters.add( "controlplane_service_id");
-        when(service.push(anyListOf(Metric.class),anyString())).thenReturn(new Control());
+        when(service.push(anyListOf(Metric.class),anyString(),any(Runnable.class))).thenReturn(new Control());
         when(request.getParameterNames()).thenReturn(Collections.enumeration(parameters));
         when(request.getParameter("controlplane_tenant_id")).thenReturn("1");
         when(request.getParameter("controlplane_service_id")).thenReturn("2");
-        when(request.getHeader("X-Forwarded-For")).thenReturn("test");
 
         PrincipalCollection principles = mock(PrincipalCollection.class);
         when(subject.getPrincipals()).thenReturn(principles);
@@ -132,7 +129,7 @@ public class MetricWebSocketTest {
         Metric expected_metric = new Metric("name", 0, 0.0);
         expected_metric.addTag("controlplane_tenant_id", "1");
         expected_metric.addTag("controlplane_service_id", "2");
-        verify(service).push(Collections.singletonList(expected_metric),"test");
+        verify(service).push(eq(Collections.singletonList(expected_metric)), eq("1"), any(Runnable.class));
     }
 
     @Test

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.*;
 public class MetricWebSocketTest {
 
     private static final int TIME_BETWEEN_BROADCAST = 1000;
+    private static final int TIME_BETWEEN_NOTIFICATION = 1000;
 
     Subject subject;
     EventBus eventBus;
@@ -62,7 +63,7 @@ public class MetricWebSocketTest {
         Control control = new Control();
         Message message = new Message(control, new Metric[]{metric});
         assertEquals(new Control(), socket.onMessage(message, new WebSocketSession(subject, request, connection)));
-        verify(service).push(eq(Collections.singletonList(metric)), eq("1"), any(Runnable.class));
+        verify(service).push(eq(Collections.singletonList(metric)), eq("websocket1"), any(Runnable.class));
     }
 
     @Test
@@ -94,7 +95,7 @@ public class MetricWebSocketTest {
         expected_metric.addTag("controlplane_tenant_id", "1");
         expected_metric.addTag("controlplane_service_id", "2");
         expected_metric.addTag("zenoss_tenant_id", "3");
-        verify(service).push(eq(Collections.singletonList(expected_metric)), eq("1"), any(Runnable.class));
+        verify(service).push(eq(Collections.singletonList(expected_metric)), eq("websocket1"), any(Runnable.class));
     }
 
     @Test
@@ -129,7 +130,7 @@ public class MetricWebSocketTest {
         Metric expected_metric = new Metric("name", 0, 0.0);
         expected_metric.addTag("controlplane_tenant_id", "1");
         expected_metric.addTag("controlplane_service_id", "2");
-        verify(service).push(eq(Collections.singletonList(expected_metric)), eq("1"), any(Runnable.class));
+        verify(service).push(eq(Collections.singletonList(expected_metric)), eq("websocket1"), any(Runnable.class));
     }
 
     @Test
@@ -180,6 +181,7 @@ public class MetricWebSocketTest {
     ConsumerAppConfiguration config(List<String> prefixes, List<String> whiteList, boolean authEnabled) {
         MetricServiceConfiguration config = new MetricServiceConfiguration();
         config.setMinTimeBetweenBroadcast(TIME_BETWEEN_BROADCAST);
+        config.setMinTimeBetweenNotification(TIME_BETWEEN_NOTIFICATION);
         ConsumerAppConfiguration appConfiguration = new ConsumerAppConfiguration();
         appConfiguration.setAuthEnabled(authEnabled);
         appConfiguration.setHttpParameterTags(prefixes);

--- a/metric-data/src/main/java/org/zenoss/app/consumer/metric/data/Control.java
+++ b/metric-data/src/main/java/org/zenoss/app/consumer/metric/data/Control.java
@@ -41,6 +41,10 @@ public final class Control {
         return new Control(Type.DATA_RECEIVED);
     }
 
+    public static Control clientCollision(String clientId) {
+        return new Control(Type.CLIENT_COLLISION, clientId);
+    }
+
 
     public enum Type {
         /** Successful processing */
@@ -60,9 +64,12 @@ public final class Control {
 
         /** Metric processing breached the high water mark, and, no metrics were processed */
         HIGH_COLLISION,
-        
+
         /** Some data has been received and processing should start */
-        DATA_RECEIVED
+        DATA_RECEIVED,
+
+        /** Metric processing breached the max backlog per client mark, however, metrics may still be processed */
+        CLIENT_COLLISION,
     }
 
     public Control() {


### PR DESCRIPTION
* Send CLIENT_COLLISION messages to websocket client while waiting on backlog.
* Add metric counter for received (not necessarily accepted) metrics.
* Add metric counter for rejected (received but not accepted) metrics.
* Log rejected metrics.
* Give each websocket connection its own clientId.
* For POSTs use X-Forwarded-For, X-ZAuth-Token, or else REMOTE_ADDR as clientId.
* Add some error handling.
* Add counters for collisions and collision broadcasts/sends
* perClientMaxBacklogSize, if unset (or zero or negative), will use a dynamic threshold, based on the number of unique recent clients.
* Add metric gauge for unique recent clients.
* The dynamic thresholding may be tweaked via perClientMaxPercentOfFairBacklogSize if desired.
* The minTimeBetweenNotification (per-client back-off notices) may be set separately from minTimeBetweenBroadcast now.
* Add prefix to web socket client IDs.