### PR TITLE
Feature/cc 575

### DIFF
--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriter.java
@@ -368,8 +368,11 @@ class OpenTsdbWriter implements TsdbWriter {
         }
         long timestamp = metric.getTimestamp();
         double value = metric.getValue();
-        Map<String, String> tags = Maps.newHashMap();
+        if (Double.isNaN(value)) {
+            throw new IllegalArgumentException("Value is NaN: %s" + metric.toString());
+        }
 
+        Map<String, String> tags = Maps.newHashMap();
         for (Entry<String, String> entry : metric.getTags().entrySet()) {
             String tagKey = sanitize(entry.getKey());
             String tagValue = sanitize(entry.getValue());

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriterTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriterTest.java
@@ -255,6 +255,36 @@ public class OpenTsdbWriterTest {
         assertEquals(expected, put);
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void testConvertRejectsNullName() {
+        long timestamp = 1000;
+        double value = 1.2;
+        HashMap<String, String> tags = new HashMap<>();
+        Metric m = new Metric(null, timestamp, value, tags);
+        OpenTsdbWriter.convert(m);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testConvertRejectsNaNValue() {
+        long timestamp = 1000;
+        double value = Double.NaN;
+        HashMap<String, String> tags = new HashMap<>();
+        Metric m = new Metric("testName", timestamp, value, tags);
+        OpenTsdbWriter.convert(m);
+    }
+
+    @Test
+    public void testConvertIgnoresNullTagName() {
+        long timestamp = 1000;
+        double value = 1.2;
+        HashMap<String, String> tags = new HashMap<>();
+        tags.put(null, "some value");
+        Metric m = new Metric("testName", timestamp, value, tags);
+        String put = OpenTsdbWriter.convert(m);
+        String expected = "put testName 1000 1.2\n";
+        assertEquals(expected, put);
+    }
+
     @Test
     public void testSanitize() {
         String input = "hello_ [{]]THERE-=)(*&^%$#@!.";

--- a/metric-zapp-reporter/src/main/java/org/zenoss/app/metric/zapp/ManagedReporterConfig.java
+++ b/metric-zapp-reporter/src/main/java/org/zenoss/app/metric/zapp/ManagedReporterConfig.java
@@ -11,19 +11,27 @@
 package org.zenoss.app.metric.zapp;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 
 import javax.validation.Valid;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * ManagedReporterConfig contains a list of metric reports configuration objects to manage by the <class><ManagedReporter/class>.
  *
  */
 public class ManagedReporterConfig {
+
     @Valid
     @JsonProperty("metricReporters")
     private List<MetricReporterConfig> metricReporters = new ArrayList<>();
+
+    @JsonProperty("defaultMetricTags")
+    private Map<String, String> defaultMetricTags = ImmutableMap.<String, String>of();
+
 
     public List<MetricReporterConfig> getMetricReporters() {
         return metricReporters;
@@ -36,4 +44,17 @@ public class ManagedReporterConfig {
     public void addMetricReporter(MetricReporterConfig metricReporterConfig) {
         metricReporters.add(metricReporterConfig);
     }
+
+    public Map<String, String> getDefaultMetricTags() {
+        return defaultMetricTags;
+    }
+
+    public void setDefaultMetricTags(Map<String, String> metricTags) {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        for (Map.Entry<String, String> entry : metricTags.entrySet()) {
+            builder.put(entry.getKey(), entry.getValue());
+        }
+        this.defaultMetricTags = builder.build();
+    }
+
 }

--- a/metric-zapp-reporter/src/test/java/org/zenoss/app/metric/zapp/ManagedReporterTest.java
+++ b/metric-zapp-reporter/src/test/java/org/zenoss/app/metric/zapp/ManagedReporterTest.java
@@ -234,29 +234,6 @@ public class ManagedReporterTest {
         verify(zmr).stop();
     }
 
-    @Test
-    public void testUnknownHost() throws Exception {
-        ManagedReporter managed = spy(new ManagedReporter(appContext, appConfig, env));
-        when(managed.getLocalHostName()).thenReturn(null);
-        String tag = managed.getHostTag();
-        Assert.assertNotNull(tag);
-        verify(managed).exectHostname();
-        when(managed.exectHostname()).thenReturn(null);
-        tag = managed.getHostTag();
-        Assert.assertEquals("UNKNOWN", tag);
-    }
-
-    @Test
-    public void testBadHostNameCmd() throws Exception {
-        ManagedReporter managed = spy(new ManagedReporter(appContext, appConfig, env));
-        when(managed.getLocalHostName()).thenReturn(null);
-        when(managed.getProcBuilder()).thenReturn(new ProcessBuilder("blamo"));
-        String tag = managed.getHostTag();
-        Assert.assertNotNull(tag);
-        verify(managed).exectHostname();
-        Assert.assertEquals("UNKNOWN", tag);
-    }
-
     abstract static class TestAppConfiguration extends AppConfiguration {
         abstract public ManagedReporterConfig getManagedReporterConfig();
     }

--- a/metric-zapp-reporter/src/test/java/org/zenoss/app/metric/zapp/ManagedReporterTest.java
+++ b/metric-zapp-reporter/src/test/java/org/zenoss/app/metric/zapp/ManagedReporterTest.java
@@ -64,6 +64,7 @@ public class ManagedReporterTest {
     private HttpPoster poster;
 
 
+    private static final String ZAPP_NAME = "TEST_NAME";
     private static final String HOST = "testHost";
     private static final String PROTOCOL = "http";
     private static final int PORT = 8888;
@@ -71,7 +72,7 @@ public class ManagedReporterTest {
 
     @Before
     public void setup() throws Exception {
-        when(env.getName()).thenReturn("TEST_NAME");
+        when(env.getName()).thenReturn(ZAPP_NAME);
         ObjectMapperFactory omf = mock(ObjectMapperFactory.class);
         when(env.getObjectMapperFactory()).thenReturn(omf);
 
@@ -89,7 +90,6 @@ public class ManagedReporterTest {
         configs.add(config);
         when(manageConfig.getMetricReporters()).thenReturn(configs);
     }
-
 
     @Test
     public void testGetUrl() throws Exception {
@@ -232,6 +232,78 @@ public class ManagedReporterTest {
         verify(zmr).start();
         mr.stop();
         verify(zmr).stop();
+    }
+
+    @Test
+    public void testDefaultTagsWithoutConfiguration() throws Exception {
+        when(config.getPosterType()).thenReturn("http");
+        ManagedReporter managed = spy(new ManagedReporter(appContext, appConfig, env));
+
+        managed.init();
+
+        Map<String, String> defaultTags = managed.getDefaultTags();
+        Assert.assertEquals("incorrect number of default tags", 2, defaultTags.size());
+        assertHardCodedTags(defaultTags);
+    }
+
+    @Test
+    public void testDefaultTagsWithConfiguration() throws Exception {
+        Map<String, String> configedTags = Maps.newHashMap();
+        configedTags.put("thing1", "blue");
+        configedTags.put("thing2", "red");
+        when(manageConfig.getDefaultMetricTags()).thenReturn(configedTags);
+        when(config.getPosterType()).thenReturn("http");
+        ManagedReporter managed = spy(new ManagedReporter(appContext, appConfig, env));
+
+        managed.init();
+
+        Map<String, String> defaultTags = managed.getDefaultTags();
+        Assert.assertEquals("incorrect number of default tags", 4, defaultTags.size());
+        assertHardCodedTags(defaultTags);
+        assertTagAndValue("thing1", "blue", defaultTags);
+        assertTagAndValue("thing2", "red", defaultTags);
+    }
+
+    @Test
+    public void testGetTagValue() throws Exception {
+        String rawValue = "something";
+        String expected = rawValue;
+        Assert.assertEquals(expected, new ManagedReporter(appContext, appConfig, env).getTagValue(rawValue));
+    }
+
+    @Test
+    public void testGetTagValueReturnsFromEnvironment() throws Exception {
+        String rawValue = "$env[CONTROLPLANE_VAR_NAME]";
+        String expected = "some expected value";
+        Map<String, String> sysEnv = Maps.newHashMap();
+        sysEnv.put("CONTROLPLANE_VAR_NAME", expected);
+        Assert.assertEquals(expected, new ManagedReporter(appContext, appConfig, env, sysEnv).getTagValue(rawValue));
+    }
+
+    @Test
+    public void testGetTagValueForNull() throws Exception {
+        String rawValue = null;
+        String expected = "";
+        Assert.assertEquals(expected, new ManagedReporter(appContext, appConfig, env).getTagValue(rawValue));
+    }
+
+    @Test
+    public void testGetTagValueForUndefinedEnvironment() throws Exception {
+        String rawValue = "$env[SOME_UNDEFINED_VAR]";
+        String expected = "";
+        Map<String, String> sysEnv = Maps.newHashMap();
+        Assert.assertEquals(expected, new ManagedReporter(appContext, appConfig, env, sysEnv).getTagValue(rawValue));
+    }
+
+    private void assertHardCodedTags(Map<String, String> tags) {
+        assertTagAndValue("daemon", ZAPP_NAME, tags);
+        assertTagAndValue("internal", "true", tags);
+    }
+
+    private void assertTagAndValue(String name, String expectedValue, Map<String, String> tags) {
+        String actualValue = tags.get(name);
+        Assert.assertNotNull("tag name '" + name + "' exists", actualValue);
+        Assert.assertEquals("tag name '" + name + "' is correct", expectedValue, actualValue);
     }
 
     abstract static class TestAppConfiguration extends AppConfiguration {


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/CC-575

Other PRs required to address CC-575:
https://github.com/control-center/serviced-isvcs/pull/17
https://github.com/control-center/serviced/pull/1710

**Question:** Are there other repos that should be updated to use metric-consumer 0.1.0 after it's published to nexus?

**Build/release steps:** 
 1. Build/publish metric-consumer 0.1.0
 2. Build/publish metric-service 0.1.0 (needs updates to use metric-consumer 0.1.0)
 3. Build/publish new isvcs docker image v28 (needs updates to use metric-consumer and central-query 0.1.0)
 4. Update serviced to use isvcs image v28