### PR TITLE
fixes ZEN-17477: log each metric sent with log level of TRACE

### DIFF
--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriter.java
@@ -193,6 +193,7 @@ class OpenTsdbWriter implements TsdbWriter {
                             processed++;
                         }
                         if (message != null) {
+                            log.trace("Publishing metric: {}", m.toString());
                             try {
                                 client.put(message);
                                 processed++;


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-17477

with log level of TRACE:
  * log each metric sent

DEMO - enable trace for consumer metric:
```
# plu@plu-9: serviced service attach metricconsumer curl --data "logger=org.zenoss.app.consumer.metric&level=TRACE" http://localhost:58443/tasks/loggerlevel
Set level TRACE on logger org.zenoss.app.consumer.metric~/src/europa
```

DEMO - attach to metricconsumer and looking for "Publishing" messages:
```
# plu@plu-9: serviced service attach metricconsumer tail -F /opt/zenoss/log/metric-consumer-app.log |egrep -i 'publishing' 
...
TRACE [2015-05-12 21:56:21,285] org.zenoss.app.consumer.metric.impl.OpenTsdbWriter: Publishing metric: Metric{metric='10.171.20.1/ssCpuUser_ssCpuUser', timestamp=1431467780, value=2.0, tags={contextUUID=fbe9e111-7d97-40d4-a94d-c766dbb38027, x-metric-consumer-client-id=websocket6, device=10.171.20.1, zenoss_tenant_id=a59fb892-f8ef-11e4-9c62-0242ac11013d, key=Devices/10.171.20.1}}
...
TRACE [2015-05-12 21:58:01,324] org.zenoss.app.consumer.metric.impl.OpenTsdbWriter: Publishing metric: Metric{metric='10.171.20.1/laLoadInt15_laLoadInt15', timestamp=1431467878, value=10.0, tags={contextUUID=fbe9e111-7d97-40d4-a94d-c766dbb38027, x-metric-consumer-client-id=websocket5, device=10.171.20.1, zenoss_tenant_id=a59fb892-f8ef-11e4-9c62-0242ac11013d, key=Devices/10.171.20.1}}
TRACE [2015-05-12 21:58:01,324] org.zenoss.app.consumer.metric.impl.OpenTsdbWriter: Publishing metric: Metric{metric='10.171.20.1/sysUpTime_sysUpTime', timestamp=1431467878, value=4.8030552E8, tags={contextUUID=fbe9e111-7d97-40d4-a94d-c766dbb38027, x-metric-consumer-client-id=websocket5, device=10.171.20.1, zenoss_tenant_id=a59fb892-f8ef-11e4-9c62-0242ac11013d, key=Devices/10.171.20.1}}
...
```