### PR TITLE
fixes ZEN-18524: temporarily disable testDoubleBroadcast() test in the support/5.0.x branch

### DIFF
--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/remote/MetricWebSocketTest.java
@@ -147,6 +147,7 @@ public class MetricWebSocketTest {
         verify(eventBus, never()).post(WebSocketBroadcast.newMessage(MetricWebSocket.class, ok));
     }
 
+    /* DISABLED this test due to ZEN-18524
     @Test
     public void testDoubleBroadcast() throws Exception {
 
@@ -173,6 +174,7 @@ public class MetricWebSocketTest {
         verify(eventBus, times(2)).post(WebSocketBroadcast.newMessage(MetricWebSocket.class, highCollision));
         verify(eventBus, never()).post(WebSocketBroadcast.newMessage(MetricWebSocket.class, ok));
     }
+    */
 
     ConsumerAppConfiguration config(boolean authEnabled) {
         return config(null, null, authEnabled);


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-18524

BEFORE:
```
# plu@plu-9: zendev devshell -d
(zenoss)[zenoss@e28dd6d303ba ~]$ cd /mnt/src/metric-consumer
(zenoss)[zenoss@e28dd6d303ba metric-consumer]$ mvn install
...
Running org.zenoss.app.consumer.metric.remote.MetricWebSocketTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.904 sec
```

AFTER removing the testDoubleBroadcast() test:
```
Running org.zenoss.app.consumer.metric.remote.MetricWebSocketTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.396 sec
```