### PR TITLE
ZEN-23199: Bump metric-tsdb to 0.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <version.dropwizard>0.6.2</version.dropwizard>
         <version.guava>14.0.1</version.guava>
         <version.yammermetrics>2.2.0</version.yammermetrics>
-        <version.metric.tsdb>0.0.8</version.metric.tsdb>
+        <version.metric.tsdb>0.0.9</version.metric.tsdb>
         <version.httpcomponents></version.httpcomponents>
         <version.jackson>2.1.4</version.jackson>
         <version.mockito>1.9.5</version.mockito>


### PR DESCRIPTION
Fixes ZEN-23199

This is just part of the fix; see the jira for more info