### PR TITLE
pull in new zapp version for java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>0.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <version.zapp>0.0.21</version.zapp>
+        <version.zapp>0.0.22</version.zapp>
         <version.junit>4.11</version.junit>
         <version.jersey>1.15</version.jersey>
         <version.dropwizard>0.6.2</version.dropwizard>


### PR DESCRIPTION
ZEN-23915: zapp was using an older version of spring, which conflicted with java 8. version 0.0.22 of zapp brings spring up to 3.2.17.RELEASE, which works with java 8. This change updates metric consumer to use the new version of zapp.