### PR TITLE
Add support for pushing metrics to Zing

### DIFF
--- a/metric-consumer-app/pom.xml
+++ b/metric-consumer-app/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>metric-tsdb</artifactId>
             <version>${version.metric.tsdb}</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
+            <scope>provided</scope>
+        </dependency>
         <!--test scope-->
         <dependency>
             <groupId>junit</groupId>

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/ConsumerSpringConfig.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/ConsumerSpringConfig.java
@@ -17,8 +17,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.zenoss.app.consumer.metric.ZingConfiguration;
 import org.zenoss.app.consumer.metric.MetricServiceConfiguration;
 import org.zenoss.lib.tsdb.OpenTsdbClientPool;
 
@@ -50,9 +52,37 @@ class ConsumerSpringConfig {
     MetricServiceConfiguration metricsServiceConfiguration() {
         return consumerAppConfiguration.getMetricServiceConfiguration();
     }
-    
+
+    @Bean
+    ZingConfiguration zingConfiguration() {
+        return this.metricsServiceConfiguration().getZingConfiguration();
+    }
+
     @Bean
     OpenTsdbClientPool openTsdbClientPool() {
         return new OpenTsdbClientPool(metricsServiceConfiguration().getOpenTsdbClientPoolConfiguration());
     }
+
+    @Bean
+    @Qualifier("zapp::executor::zing")
+    ExecutorService zingExecutorService() {
+        // Note that ZingQueue is unbounded, so there's no point in having separate min/max thread pool sizes
+        ZingConfiguration zingConfig = metricsServiceConfiguration().getZingConfiguration();
+        return dropwizardEnvironment.managedExecutorService(
+                "Zing Executor %d",
+                zingConfig.getThreadPoolSize(),
+                zingConfig.getThreadPoolSize(),
+                5, TimeUnit.SECONDS);
+
+    }
+
+    @Bean
+    @Qualifier("zapp::executor::scheduled")
+    ScheduledExecutorService scheduledExecutorService() {
+        // The scheduler only runs once, so it doesn't need a pool bigger than 1
+        return dropwizardEnvironment.managedScheduledExecutorService(
+                "Scheduled Executor %d",
+                1);
+    }
+
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricServiceConfiguration.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/MetricServiceConfiguration.java
@@ -118,6 +118,9 @@ public class MetricServiceConfiguration {
     @JsonProperty
     private int selfReportFrequency = 0; // Zero means no reporting
 
+    @Valid
+    private ZingConfiguration zingConfiguration = new ZingConfiguration();
+
     /**
      * TSDB client pool configuration.
      *
@@ -437,5 +440,23 @@ public class MetricServiceConfiguration {
      */
     public void setTsdbWriterThreads(int numberOfThreads) {
         this.tsdbWriterThreads = numberOfThreads;
+    }
+
+    /**
+     * The configuration for exporting metrics to Zing.
+     *
+     * @return zingConfiguration
+     */
+    public ZingConfiguration getZingConfiguration() {
+        return zingConfiguration;
+    }
+
+    /**
+     * The configuration for exporting metrics to Zing.
+     *
+     * @param zingConfiguration the new configuration for the integration with Zing
+     */
+    public void setZingConfiguration(ZingConfiguration zingConfiguration) {
+        this.zingConfiguration = zingConfiguration;
     }
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingConfiguration.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ZingConfiguration {
+    /**
+     * True if integration with Zing is enabled.
+     *
+     * @param enabled
+     * @return enabled
+     */
+    @JsonProperty
+    private boolean enabled = false;
+
+    /**
+     * The thread pool size for the pool of threads sending data to Zing.
+     *
+     * @param threadPoolSize
+     * @return threadPoolSize
+     */
+    @Min(1)
+    @JsonProperty
+    private int threadPoolSize = 1;
+
+    /**
+     * The number of writer threads used to send data Zing.
+     *
+     * @param writerThreads
+     * @return writerThreads
+     */
+    @Min(1)
+    @JsonProperty
+    private int writerThreads = 1;
+
+    /**
+     * The batch size for sending data to Zing.
+     *
+     * @param batchSize
+     * @return batchSize
+     */
+    @Min(1)
+    @JsonProperty
+    private int batchSize = 5;
+
+    /**
+     * Max time in milliseconds with no work before writer threads will commit seppuku
+     *
+     * @param maxIdleTime
+     * @return maxIdleTime
+     */
+    @Min(1000)
+    @JsonProperty
+    private int maxIdleTime = 10000;
+
+    /**
+     * The Zing URL endpoint which receives metrics from MetricConsumer.
+     *
+     * @param endpoint
+     * @return endpoint
+     */
+    @NotNull
+    @JsonProperty
+    private String endpoint = "";
+}

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingSender.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingSender.java
@@ -1,0 +1,19 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric;
+
+import org.zenoss.app.consumer.metric.data.Metric;
+
+import java.util.Collection;
+
+public interface ZingSender {
+    void send(Collection<Metric> metrics) throws Exception;
+}

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriterManager.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbWriterManager.java
@@ -39,8 +39,8 @@ class OpenTsdbWriterManager {
     @Autowired
     OpenTsdbWriterManager(
             ApplicationContext appContext, 
-            MetricServiceConfiguration config, 
-            @Qualifier("zapp::event-bus::async") EventBus eventBus, 
+            MetricServiceConfiguration config,
+            @Qualifier("zapp::event-bus::async") EventBus eventBus,
             @Qualifier("zapp::executor::metrics") ExecutorService executorService,
             TsdbWriterRegistry writerRegistry)
     {

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingConnectorSender.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingConnectorSender.java
@@ -1,0 +1,130 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.zenoss.app.consumer.metric.ZingConfiguration;
+import org.zenoss.app.consumer.metric.ZingSender;
+import org.zenoss.app.consumer.metric.data.Metric;
+import org.zenoss.app.consumer.metric.data.MetricCollection;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+/**
+ * @see ZingSender
+ */
+@Component
+public class ZingConnectorSender implements ZingSender {
+    private static final Logger log = LoggerFactory.getLogger(ZingConnectorSender.class);
+
+    private static final DefaultHttpClient newHttpClient() {
+        // TODO: make retry count configurable
+        // TODO: make http connect timeout configurable
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+        httpClient.setHttpRequestRetryHandler( new DefaultHttpRequestRetryHandler(0, true));
+        return httpClient;
+    }
+
+    private final HttpClient httpClient;
+
+    private final ZingConfiguration configuration;
+
+    private final ObjectMapper mapper;
+
+    ZingConnectorSender(ZingConfiguration configuration, HttpClient httpClient) {
+        this.configuration = configuration;
+        this.httpClient = httpClient;
+        this.mapper = new ObjectMapper();
+    }
+
+    @Autowired
+    public ZingConnectorSender(ZingConfiguration configuration) {
+        this(configuration, newHttpClient());
+    }
+
+    @Override
+    public void send(Collection<Metric> metrics) throws Exception {
+        log.debug("sending {} metrics to {}", metrics.size(), configuration.getEndpoint());
+        URL url = new URL(configuration.getEndpoint());
+        HttpPut request = new HttpPut(url.toURI());
+        setHeaders(request);
+        setPayload(request, metrics);
+        sendRequest(request);
+    }
+
+    private void setHeaders(HttpPut request) {
+        request.addHeader("content-type", "application/json");
+        request.addHeader("Accept", "*/*");
+        request.addHeader("Accept-Language", "en-US,en;q=0.8");
+    }
+
+    private void setPayload(HttpPut request, Collection<Metric> metrics) throws Exception {
+        StringEntity payload = new StringEntity(toJson(metrics),"UTF-8");
+        payload.setContentType("application/json");
+        request.setEntity(payload);
+    }
+
+    private void sendRequest(HttpPut request) throws IOException {
+        HttpResponse response = null;
+        try {
+            response = httpClient.execute(request);
+            StatusLine statusLine = response.getStatusLine();
+            int statusCode = statusLine.getStatusCode();
+            log.debug( "Send request complete with status: {}", statusCode);
+            if (statusCode >= 200 && statusCode <= 299) {
+                HttpEntity entity = response.getEntity();
+                log.debug("Response: {}", entity == null ? null : EntityUtils.toString(entity));
+            } else {
+                log.warn( "Unsuccessful response from server: {}", response.getStatusLine());
+                throw new IOException(String.format("Failed to send metrics: %s", response.getStatusLine()));
+            }
+        } catch (ConnectException ex) {
+            log.warn(String.format("Connection to %s failed: %s", request.getURI(), ex));
+            throw ex;
+        } finally {
+            try {
+                if (response != null) {
+                    HttpEntity entity = response.getEntity();
+                    if (entity != null) {
+                        response.getEntity().getContent().close();
+                    }
+                }
+            } catch( NullPointerException | IOException ex) {
+                log.warn( "Failed to close request: {}", ex);
+            }
+        }
+    }
+
+    private String toJson(Collection<Metric> metrics) throws JsonProcessingException {
+        MetricCollection mc = new MetricCollection();
+        mc.setMetrics(new ArrayList<Metric>(metrics));
+        return mapper.writeValueAsString(mc);
+    }
+}

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingQueue.java
@@ -1,0 +1,86 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.zenoss.app.consumer.metric.data.Metric;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A threadsafe queue to distribute metrics bound for Zing across multiple sender threads.
+ *
+ * TODO - add yammer Metrics to monitor the state of the queue
+ */
+@Component
+public class ZingQueue {
+    private static final Logger logger = LoggerFactory.getLogger(ZingQueue.class);
+    private BlockingQueue<Metric> queue = null;
+
+    public ZingQueue() {
+        this.queue = new LinkedBlockingQueue<Metric>();
+    }
+
+
+    /**
+     * Retrieves and removes a number of elements from the queue. If there are
+     * not enough elements in the queue to satisfy the request, then the entire
+     * contents of the queue will be returned.
+     *
+     * @param size          desired number elements to retrieve
+     * @param maxWaitMillis max time to wait if the queue is initially empty
+     * @return removed elements
+     */
+    Collection<Metric> poll(int size, long maxWaitMillis) throws InterruptedException {
+        logger.debug("Polling. size = {}, queue size = {}", size, queue.size());
+        final Metric first = queue.poll(maxWaitMillis, TimeUnit.MILLISECONDS);
+        if (first == null) {
+            logger.debug("Unable to retrieve a single element after max wait");
+            return Collections.emptyList();
+        }
+
+        final Collection<Metric> metrics = new ArrayList<Metric>(size);
+        metrics.add(first);
+
+        while (metrics.size() < size) {
+            final Metric m = queue.poll();
+            if (m == null) {
+                logger.debug("No more metrics in queue, retrieved {} metrics", metrics.size());
+                break;
+            }
+            metrics.add(m);
+        }
+
+
+        return metrics;
+    }
+
+    /**
+     * Add elements to the queue.
+     *
+     * @param metrics  added elements
+     * @param clientId an identifier for the remote client that is adding the metrics.
+     */
+    void addAll(Collection<Metric> metrics) {
+        queue.addAll(metrics);
+    }
+
+    int size() {
+        return this.queue.size();
+    }
+}

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingWriter.java
@@ -1,0 +1,187 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.zenoss.app.consumer.metric.ZingConfiguration;
+import org.zenoss.app.consumer.metric.ZingSender;
+import org.zenoss.app.consumer.metric.data.Metric;
+
+import java.util.Collection;
+
+
+/**
+ * Pulls from a queue of metrics and sends batches of them to Zing.
+ */
+@Component
+public class ZingWriter implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(ZingWriter.class);
+
+    private ZingConfiguration zingConfiguration;
+
+    /**
+     * The queue containing metrics to send
+     */
+    private ZingQueue zingQueue;
+
+    /**
+     * used to register/track writer threads
+     */
+    private final ZingWriterRegistry writerRegistry;
+
+    /**
+     * Used to send a batch of metrics to the Zing.
+     */
+    private final ZingSender sender;
+
+    /**
+     * Size of batches to send to the Zing socket
+     */
+    private final int batchSize;
+
+    /**
+     * Max idle time before suicide
+     */
+    private final int maxIdleTime;
+
+    /**
+     * Is this instance currently running?
+     */
+    private transient boolean running;
+
+    /**
+     * Has this instance been canceled?
+     */
+    private transient boolean canceled;
+
+    /**
+     * Last time this instance did work
+     */
+    protected transient long lastWorkTime;
+
+    @Autowired
+    ZingWriter(ZingConfiguration config,
+               ZingWriterRegistry registry,
+               ZingQueue zingQueue,
+               ZingSender sender) {
+        this.zingConfiguration = config;
+        this.writerRegistry = registry;
+        this.zingQueue = zingQueue;
+        this.sender= sender;
+
+        this.batchSize = zingConfiguration.getBatchSize();
+        this.maxIdleTime = zingConfiguration.getMaxIdleTime();
+        this.running = false;
+        this.canceled = false;
+        this.lastWorkTime = 0;
+    }
+
+    @Override
+    public void run() {
+        log.info("Starting writer");
+        try {
+            writerRegistry.register(this);
+            running = true;
+            runUntilCanceled();
+        } catch (InterruptedException ie) {
+            log.info("Exiting due to thread interrupt");
+            Thread.currentThread().interrupt();
+        } catch (RuntimeException e) {
+            log.error("Thread exiting due to unexpected exception", e);
+            throw e;
+        } finally {
+            running = false;
+            writerRegistry.unregister(this);
+        }
+    }
+
+    void runUntilCanceled() throws InterruptedException {
+
+        while (!isCanceled()) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+            Collection<Metric> metrics = zingQueue.poll(batchSize, maxIdleTime);
+            log.debug("Back from polling zingQueue. metrics.size = {}",
+                    null == metrics ? "null" : metrics.size());
+            // Check to see if we should down this writer entirely.
+            log.debug("Checking for shutdown. lastWorkTime = {}; maxIdleTime = {}; sum = {}; currentTime ={}",
+                    lastWorkTime, maxIdleTime, lastWorkTime + maxIdleTime, System.currentTimeMillis());
+            if (isNullOrEmpty(metrics) && // No records could be read from the
+                    // metrics queue
+                    lastWorkTime > 0 && // This thread has done work at least
+                    // once
+                    maxIdleTime > 0 && // The max idle time is set to something
+                    // meaningful
+                    System.currentTimeMillis() > lastWorkTime + maxIdleTime) // The
+            // max
+            // idle
+            // time
+            // has
+            // expired
+            {
+                log.info("Shutting down writer due to dearth of work");
+                break;
+            }
+
+            /*
+             * If all the conditions were not met for shutting this writer down,
+             * we still might want to just abort this run if we didn't get any
+             * data from the metrics queue
+             */
+            if (isNullOrEmpty(metrics)) {
+                log.debug("No work to do, so checking again.");
+                continue;
+            }
+
+            // We have some work to do, some process what we got from the
+            // metrics queue
+            processBatch(metrics);
+        }
+        log.debug("work canceled.");
+    }
+
+    private boolean isNullOrEmpty(Collection<Metric> metrics) {
+        return null == metrics || metrics.isEmpty();
+    }
+
+    void processBatch(Collection<Metric> metrics) {
+        try {
+            log.debug("processBatch, size={}, batch={}", metrics.size(), metrics);
+            sender.send(metrics);
+
+        } catch (Exception e) {
+            // TODO: Should we requeue the batch of metrics at this point?
+            //       Otherwise, the batch is lost
+            log.warn("Caught exception while processing metrics: {}", e.getMessage());
+
+        } finally {
+            lastWorkTime = System.currentTimeMillis();
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    private synchronized boolean isCanceled() {
+        return canceled;
+    }
+
+    public synchronized void cancel() {
+        log.info("Writer shutdown requested");
+        this.canceled = true;
+    }
+
+}

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingWriterManager.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingWriterManager.java
@@ -1,0 +1,119 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.zenoss.app.consumer.metric.ZingConfiguration;
+import org.zenoss.app.consumer.metric.MetricServiceConfiguration;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the number of threads writing to Zing.
+ */
+@Component
+public class ZingWriterManager implements Runnable  {
+    private static final Logger logger = LoggerFactory.getLogger(ZingWriterManager.class);
+    private static int ALLOWED_LAG_CYCLES = 3;
+    private ApplicationContext appContext = null;
+    private ExecutorService executorService = null;
+    private ScheduledExecutorService scheduledExecutorService = null;
+    private ZingQueue zingQueue = null;
+    private ZingConfiguration zingConfiguration = null;
+    private int maxWriterThreads = 1;
+    private ScheduledFuture<?> scheduledTask = null;
+    private ZingWriterRegistry writers = null;
+
+    @Autowired
+    ZingWriterManager(ApplicationContext appContext,
+                      MetricServiceConfiguration config,
+                      ZingQueue zingQueue,
+                      ZingWriterRegistry writerRegistry,
+                      @Qualifier("zapp::executor::zing") ExecutorService executorService,
+                      @Qualifier("zapp::executor::scheduled") ScheduledExecutorService scheduledExecutorService) {
+        this.appContext = appContext;
+        this.executorService = executorService;
+        this.scheduledExecutorService = scheduledExecutorService;
+        this.zingQueue = zingQueue;
+        this.writers = writerRegistry;
+        this.zingConfiguration = config.getZingConfiguration();
+        this.maxWriterThreads = zingConfiguration.getWriterThreads();
+    }
+
+    @PostConstruct
+    public void schedule() {
+        // There's no need to spin up threads that will never be called
+        if (!this.zingConfiguration.isEnabled()) {
+            logger.debug("Zing integration disabled - not scheduling anything");
+            return;
+        }
+
+        if (this.scheduledTask == null) {
+            logger.debug("Scheduling ZingWriterManager");
+
+            this.scheduledTask = scheduledExecutorService.scheduleWithFixedDelay(this, 0L, 30,
+                    TimeUnit.SECONDS);
+        } else {
+            logger.warn("Attempt to re-schedule ZingWriterManager!");
+        }
+    }
+
+    public void run() {
+        int needed = needMoreWriters();
+        int created = 0;
+
+        while (needed-- > 0) {
+            ZingWriter writer = appContext.getBean(ZingWriter.class);
+            this.executorService.submit(writer);
+            ++created;
+        }
+        logger.debug("Created {} writers", created);
+    }
+
+    private int needMoreWriters() {
+        //
+        int current = writers.size();
+        int needed = 0;
+
+        if (current == 0) {
+            // first time around
+            needed = 1;
+        } else {
+            int lagCycles = Math.floorDiv(this.zingQueue.size(), current * this.zingConfiguration.getBatchSize());
+            if (lagCycles > ALLOWED_LAG_CYCLES) {
+                needed = 2 * current;
+            }
+        }
+        logger.debug("Writers needed: {}", needed);
+
+        if (needed > 0) {
+            if (current >= this.maxWriterThreads) {
+                logger.debug("Current writers count exceeds allowed: {}", this.maxWriterThreads);
+                needed = 0;
+            } else if ((current + needed) > maxWriterThreads) {
+                needed = maxWriterThreads - current;
+                logger.debug("Current + needed writers count exceeds allowed: {}. Adjusting needed to {}",
+                        this.maxWriterThreads, needed);
+            }
+        }
+
+        return needed;
+    }
+}

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingWriterRegistry.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/ZingWriterRegistry.java
@@ -1,0 +1,70 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zenoss.dropwizardspring.annotations.Managed;
+
+import java.util.Collection;
+
+
+/**
+ * This class tracks currently running Zing writer threads and informs them
+ * when the dropwizard container is shutting down.
+ */
+@Managed
+class ZingWriterRegistry implements com.yammer.dropwizard.lifecycle.Managed {
+
+    private static final Logger log = LoggerFactory.getLogger(ZingWriterRegistry.class);
+
+    ZingWriterRegistry() {
+        this.createdWriters = Lists.newCopyOnWriteArrayList();
+    }
+
+
+    public void register(ZingWriter writer) {
+        log.debug("Adding writer");
+        createdWriters.add(writer);
+    }
+
+
+    public void unregister(ZingWriter writer) {
+        log.debug("Removing writer");
+        createdWriters.remove(writer);
+    }
+
+    public int size() {
+        return createdWriters.size();
+    }
+
+    @Override
+    public void start() throws Exception {
+        log.debug("Starting");
+    }
+
+    @Override
+    public synchronized void stop() throws Exception {
+        int count = 0;
+        for (ZingWriter writer : createdWriters) {
+            writer.cancel();
+            count++;
+        }
+        log.info("Shutdown {} writer(s)", count);
+    }
+
+    // State
+    private final Collection<ZingWriter> createdWriters;
+}
+
+
+

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricServiceTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricServiceTest.java
@@ -31,16 +31,18 @@ public class OpenTsdbMetricServiceTest {
     MetricServiceConfiguration config;
     EventBus eventBus;
     MetricsQueue metricsQueue;
+    ZingQueue zingQueue;
 
     @Before
     public void setUp() {
         eventBus = mock(EventBus.class);
         config = new MetricServiceConfiguration();
         metricsQueue = mock(MetricsQueue.class);
+        zingQueue = mock(ZingQueue.class);
     }
     
     OpenTsdbMetricService newService() {
-        return new OpenTsdbMetricService(config, eventBus, metricsQueue);
+        return new OpenTsdbMetricService(config, eventBus, metricsQueue, zingQueue);
     }
 
     @Test
@@ -58,6 +60,18 @@ public class OpenTsdbMetricServiceTest {
         OpenTsdbMetricService service = newService();
         assertEquals(Control.ok(), service.push(metrics, "test", null));
         verify(metricsQueue, times(1)).addAll(metrics, "test");
+        verify(zingQueue, times(0)).addAll(metrics);
+    }
+
+    @Test
+    public void testPushToZing() throws Exception {
+        config.getZingConfiguration().setEnabled(true);
+        Metric metric = new Metric("name", 0, 0.0);
+        List<Metric> metrics  = Collections.singletonList(metric);
+        OpenTsdbMetricService service = newService();
+        assertEquals(Control.ok(), service.push(metrics, "test", null));
+        verify(metricsQueue, times(1)).addAll(metrics, "test");
+        verify(zingQueue, times(1)).addAll(metrics);
     }
 
     @Test

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingConnectorSenderTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingConnectorSenderTest.java
@@ -1,0 +1,124 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import com.google.api.client.util.Maps;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPut;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.zenoss.app.consumer.metric.ZingConfiguration;
+import org.zenoss.app.consumer.metric.data.Metric;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ZingConnectorSenderTest {
+
+    ZingConfiguration config;
+
+    HttpClient httpClient;
+
+    ZingConnectorSender sender;
+
+    @Before
+    public void setUp() throws Exception {
+        config = mock(ZingConfiguration.class);
+        when(config.getEndpoint()).thenReturn("http://localhost:9237");
+        httpClient = mock(HttpClient.class);
+    }
+
+    @Test
+    public void testPutWorks() throws Exception {
+        sender = new ZingConnectorSender(config, httpClient);
+
+        final HttpResponse response = mock(HttpResponse.class);
+
+        final StatusLine status = mock(StatusLine.class);
+        when(response.getStatusLine()).thenReturn(status);
+        when(status.getStatusCode()).thenReturn(200);
+
+        when(response.getEntity()).thenReturn(null);
+
+        when(httpClient.execute((HttpPut) anyObject())).thenReturn(response);
+
+        ArgumentCaptor<HttpPut> arg = ArgumentCaptor.forClass(HttpPut.class);
+
+        Collection<Metric> batch = new ArrayList<Metric>(1);
+        Map<String, String> tags = Maps.newHashMap();
+        Metric metric = new Metric("metric", 0, 0, tags);
+        batch.add(metric);
+
+        sender.send(batch);
+
+        verify(httpClient).execute(arg.capture());
+        assertEquals(config.getEndpoint(), arg.getValue().getURI().toString());
+        assertEquals("Content-Type: application/json", arg.getValue().getEntity().getContentType().toString());
+    }
+
+    @Test
+    public void testPutFailsOn400() throws Exception {
+        sender = new ZingConnectorSender(config, httpClient);
+
+        final HttpResponse response = mock(HttpResponse.class);
+
+        final StatusLine status = mock(StatusLine.class);
+        when(response.getStatusLine()).thenReturn(status);
+        when(status.getStatusCode()).thenReturn(400);
+
+        when(response.getEntity()).thenReturn(null);
+
+        when(httpClient.execute((HttpPut) anyObject())).thenReturn(response);
+
+        Collection<Metric> batch = new ArrayList<Metric>(1);
+        Map<String, String> tags = Maps.newHashMap();
+        Metric metric = new Metric("metric", 0, 0, tags);
+        batch.add(metric);
+
+        try {
+            sender.send(batch);
+        } catch (IOException e) {
+            String expected = "Failed to send metrics";
+            assertEquals(expected, e.getMessage().substring(0, expected.length()));
+        }
+    }
+
+    @Test
+    public void testPutFailsOnBadURI() throws Exception {
+        sender = new ZingConnectorSender(config, httpClient);
+
+        when(httpClient.execute((HttpPut) anyObject())).thenThrow(new ConnectException());
+
+        Collection<Metric> batch = new ArrayList<Metric>(1);
+        Map<String, String> tags = Maps.newHashMap();
+        Metric metric = new Metric("metric", 0, 0, tags);
+        batch.add(metric);
+
+        try {
+            sender.send(batch);
+        } catch (ConnectException e) {
+            // we got it!
+        }
+    }
+}

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingQueueTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingQueueTest.java
@@ -1,0 +1,157 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+import org.zenoss.app.consumer.metric.data.Metric;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class ZingQueueTest {
+
+
+    @Test
+    public void testSize() {
+        final ZingQueue mq = new ZingQueue();
+        Assert.assertEquals(0, mq.size());
+
+        final Collection<Metric> toAdd = Lists.newArrayList(new Metric("fake", System.currentTimeMillis(), 123.45));
+        mq.addAll(toAdd);
+
+        Assert.assertEquals(1, mq.size());
+    }
+
+    @Test
+    public void testPollForEmptyQueue() throws InterruptedException, ExecutionException, TimeoutException {
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        final ZingQueue mq = new ZingQueue();
+        final int maxPollSize = 2;
+        final long maxPollWait = 500; // a really short time.
+        final Poller pollsOnce = new Poller(mq, maxPollSize, maxPollWait);
+        Future<?> pollingFuture = executorService.submit(pollsOnce);
+
+        pollingFuture.get(1, TimeUnit.SECONDS);
+
+        Assert.assertEquals(0, pollsOnce.getRetrieved().size());
+    }
+
+    @Test
+    public void testPollForMaxSize() throws InterruptedException, ExecutionException, TimeoutException {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        final ZingQueue mq = new ZingQueue();
+        final int maxPollSize = 5;
+        final long maxPollWait = 30000L; // a really long time.
+        final Poller pollsOnce = new Poller(mq, maxPollSize, maxPollWait);
+        Future<?> pollingFuture = executorService.submit(pollsOnce);
+        final Collection<Metric> toAdd = Lists.newArrayList(
+                new Metric("fake1", System.currentTimeMillis(), 123.45),
+                new Metric("fake2", System.currentTimeMillis(), 123.46),
+                new Metric("fake3", System.currentTimeMillis(), 123.47),
+                new Metric("fake4", System.currentTimeMillis(), 123.48),
+                new Metric("fake5", System.currentTimeMillis(), 123.49));
+
+        while (!pollsOnce.isStarted()) {
+            Thread.sleep(10);
+        }
+
+        Runnable addsOnce = new Adder(mq, toAdd);
+        Future<?> addingFuture = executorService.submit(addsOnce);
+
+        pollingFuture.get(1, TimeUnit.SECONDS);
+        addingFuture.get(1, TimeUnit.SECONDS);
+
+        Assert.assertEquals(maxPollSize, pollsOnce.getRetrieved().size());
+        Assert.assertEquals(toAdd, pollsOnce.getRetrieved());
+        Assert.assertEquals(0, mq.size());  // the queue should be drained
+        executorService.shutdownNow();
+    }
+
+    @Test
+    public void testWaitAndNotify() throws InterruptedException, ExecutionException, TimeoutException {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        final ZingQueue mq = new ZingQueue();
+        final Collection<Metric> toAdd = Lists.newArrayList(new Metric("fake", System.currentTimeMillis(), 123.45));
+        final int maxPollSize = 2;
+        final long maxPollWait = 30000L; // a really long time.
+        final Poller pollsOnce = new Poller(mq, maxPollSize, maxPollWait);
+        Future<?> pollingFuture = executorService.submit(pollsOnce);
+        
+        while (!pollsOnce.isStarted()) {
+            Thread.sleep(10);
+        }
+        
+        Runnable addsOnce = new Adder(mq, toAdd);
+        Future<?> addingFuture = executorService.submit(addsOnce);
+        
+        pollingFuture.get(1, TimeUnit.SECONDS);
+        addingFuture.get(1, TimeUnit.SECONDS);
+        
+        Assert.assertEquals(toAdd, pollsOnce.getRetrieved());
+        Assert.assertEquals(0, mq.size());  // the queue should be drained
+        executorService.shutdownNow();
+    }
+    
+    static class Poller implements Runnable {
+        
+        private Collection<Metric> retrieved;
+        private final ZingQueue mq;
+        private final int maxPollSize;
+        private final long maxPollWait;
+        private boolean started = false;
+
+        public Poller(ZingQueue mq, int maxPollSize, long maxPollWait) {
+            this.mq = mq;
+            this.maxPollSize = maxPollSize;
+            this.maxPollWait = maxPollWait;
+        }
+        
+        @Override
+        public void run() {
+            started = true;
+            try {
+                retrieved = mq.poll(maxPollSize, maxPollWait);
+            } 
+            catch(InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        
+        boolean isStarted() {
+            return started;
+        }
+        
+        Collection<Metric> getRetrieved() {
+            return retrieved;
+        }
+    }
+    
+    static class Adder implements Runnable {
+        private final Collection<Metric> toAdd;
+        private final ZingQueue mq;
+        public Adder(ZingQueue mq, Collection<Metric> toAdd) {
+            this.toAdd = toAdd;
+            this.mq = mq;
+        }
+
+        @Override
+        public void run() {
+            mq.addAll(toAdd);
+        }
+    }
+}

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingWriterManagerTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingWriterManagerTest.java
@@ -1,0 +1,141 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.zenoss.app.consumer.metric.MetricServiceConfiguration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ */
+public class ZingWriterManagerTest {
+ 
+    ApplicationContext context;
+    MetricServiceConfiguration config;
+    ZingQueue queue;
+    ZingWriterRegistry registry;
+    ExecutorService executorService;
+    ScheduledExecutorService scheduledExecutorService;
+
+    @Before
+    public void setUp() {
+        context = mock(ApplicationContext.class);
+        config = new MetricServiceConfiguration();
+        queue = mock(ZingQueue.class);
+        registry = mock(ZingWriterRegistry.class);
+        executorService = mock(ExecutorService.class);
+        scheduledExecutorService = mock(ScheduledExecutorService.class);
+    }
+
+    ZingWriterManager createManager() {
+        return new ZingWriterManager(context, config, queue, registry, executorService, scheduledExecutorService);
+    }
+
+    @Test
+    public void testNothingScheduledWhenZingDisabled() {
+        config.getZingConfiguration().setEnabled(false);
+        ZingWriterManager manager = createManager();
+        manager.schedule();
+
+        verify(scheduledExecutorService, never()).scheduleWithFixedDelay(manager, 0L, 30L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testManagerScheduledWhenZingEnabled() {
+        config.getZingConfiguration().setEnabled(true);
+        ZingWriterManager manager = createManager();
+
+        manager.schedule();
+
+        verify(scheduledExecutorService, times(1)).scheduleWithFixedDelay(manager, 0L, 30L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testManagerScheduledExactlyOnce() {
+        config.getZingConfiguration().setEnabled(true);
+        ZingWriterManager manager = createManager();
+        ScheduledFuture future = mock(ScheduledFuture.class);
+        when(scheduledExecutorService.scheduleWithFixedDelay(manager, 0L, 30L, TimeUnit.SECONDS)).thenReturn(future);
+
+        manager.schedule();
+        manager.schedule();
+        verify(scheduledExecutorService, times(1)).scheduleWithFixedDelay(manager, 0L, 30L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testRunCreatesNoWriters() {
+        config.getZingConfiguration().setBatchSize(1);
+        config.getZingConfiguration().setWriterThreads(1);
+        ZingWriterManager manager = createManager();
+        when(registry.size()).thenReturn(1);
+        when(queue.size()).thenReturn(1);
+
+        manager.run();
+
+        verify(executorService, never()).submit((ZingWriter) anyObject());
+    }
+
+    @Test
+    public void testRunCreatesOneWriter() {
+        config.getZingConfiguration().setBatchSize(1);
+        config.getZingConfiguration().setWriterThreads(1);
+        ZingWriterManager manager = createManager();
+        when(registry.size()).thenReturn(0);
+        when(queue.size()).thenReturn(1);
+
+        manager.run();
+
+        verify(executorService, times(1)).submit((ZingWriter)anyObject());
+    }
+
+    @Test
+    public void testRunCreatesTwoWriters() {
+        final int maxThreadCount = 3;
+        final int currentThreadCount = 1;
+        final int expectedWriterCount = maxThreadCount - currentThreadCount;
+
+        config.getZingConfiguration().setBatchSize(10);
+        config.getZingConfiguration().setWriterThreads(maxThreadCount);
+        ZingWriterManager manager = createManager();
+        when(registry.size()).thenReturn(currentThreadCount);
+        when(queue.size()).thenReturn(41);
+
+        manager.run();
+
+        verify(executorService, times(expectedWriterCount)).submit((ZingWriter)anyObject());
+    }
+
+    // Setup the input values such that the algorithm *wants* to add 2 more threads (lagCycles > LAG_CYCLES),
+    // but can't add any more because the thread limit has already been reached
+    @Test
+    public void testRunReachesWriterMax() {
+        final int maxThreadCount = 2;
+
+        config.getZingConfiguration().setBatchSize(10);
+        config.getZingConfiguration().setWriterThreads(maxThreadCount);
+        ZingWriterManager manager = createManager();
+        when(registry.size()).thenReturn(maxThreadCount);
+        when(queue.size()).thenReturn(81);
+
+        manager.run();
+
+        verify(executorService, never()).submit((ZingWriter) anyObject());
+    }
+}

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingWriterTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/ZingWriterTest.java
@@ -1,0 +1,171 @@
+/*
+ * ****************************************************************************
+ *
+ *  Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+ *
+ *  This content is made available according to terms specified in
+ *  License.zenoss distributed with this file.
+ *
+ * ***************************************************************************
+ */
+package org.zenoss.app.consumer.metric.impl;
+
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zenoss.app.consumer.metric.ZingConfiguration;
+import org.zenoss.app.consumer.metric.ZingSender;
+import org.zenoss.app.consumer.metric.data.Metric;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ZingWriterTest {
+
+    static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
+
+    ZingConfiguration configuration;
+    ExecutorService executor;
+    ZingWriterRegistry registry;
+    ZingQueue metricsQueue;
+    ZingSender sender;
+
+    @Before
+    public void setUp() {
+        configuration = new ZingConfiguration();
+        configuration.setMaxIdleTime(1);
+        metricsQueue = new ZingQueue();
+
+        registry = mock(ZingWriterRegistry.class);
+        sender = mock(ZingSender.class);
+        executor = Executors.newSingleThreadExecutor();
+
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        final Metric metric = new Metric("metric", 0, 0);
+        ZingQueue mq = mock(ZingQueue.class);
+
+        configuration.setMaxIdleTime(0); // Never quit due to lack of work
+        ZingWriter writer = new ZingWriter(configuration, registry, mq, sender);
+
+        Future<?> future = executor.submit(writer);
+        boolean writerStarted = false;
+        for (int tries = 0; tries < 50 && !writerStarted; tries++) {
+            writerStarted = writer.isRunning();
+            Thread.sleep(10);
+        }
+        if (!writerStarted) {
+            fail("Writer could not be started");
+        }
+
+        writer.cancel();
+        future.get(1, TimeUnit.SECONDS);
+        assertFalse(writer.isRunning());
+    }
+
+    @Test
+    public void testInterrupt() throws Exception {
+        final Metric metric = new Metric("metric", 0, 0);
+        ZingQueue mq = mock(ZingQueue.class);
+
+        configuration.setMaxIdleTime(0); // Never quit due to lack of work
+        ZingWriter writer = new ZingWriter(configuration, registry, mq, sender);
+
+        executor.submit(writer);
+
+        boolean writerStarted = false;
+        for (int tries = 0; tries < 50 && !writerStarted; tries++) {
+            writerStarted = writer.isRunning();
+            Thread.sleep(10);
+        }
+        if (!writerStarted) {
+            fail("Writer could not be started");
+        }
+
+        executor.shutdownNow();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+        assertFalse(writer.isRunning());
+    }
+
+    @Test
+    public void testSubmitSuccess() throws Exception {
+        ZingWriter writer = new ZingWriter(configuration, registry, metricsQueue, sender);
+        executor.submit(writer);
+
+        boolean writerStarted = false;
+        for (int tries = 0; tries < 50 && !writerStarted; tries++) {
+            writerStarted = writer.isRunning();
+            Thread.sleep(10);
+        }
+        if (!writerStarted) {
+            fail("Writer could not be started");
+        }
+
+        final Metric metric = new Metric("metric", 0, 0);
+        Collection<Metric> batch = Lists.newArrayList(metric);
+
+        metricsQueue.addAll(batch);
+
+        boolean writerIsRunning = writer.isRunning();
+        for (int tries = 0; tries < 50 && writerIsRunning; tries++) {
+            writerIsRunning = writer.isRunning();
+            Thread.sleep(10);
+        }
+        if (writerIsRunning) {
+            fail("Writer did not stop after all work completed");
+        }
+
+        assertEquals(0, metricsQueue.size());
+    }
+
+    @Test
+    public void testSubmitStopsAfterSendFailure() throws Exception {
+        ZingWriter writer = new ZingWriter(configuration, registry, metricsQueue, sender);
+        executor.submit(writer);
+
+        boolean writerStarted = false;
+        for (int tries = 0; tries < 50 && !writerStarted; tries++) {
+            writerStarted = writer.isRunning();
+            Thread.sleep(10);
+        }
+        if (!writerStarted) {
+            fail("Writer could not be started");
+        }
+
+        final Metric metric = new Metric("metric", 0, 0);
+        Collection<Metric> batch = Lists.newArrayList(metric);
+
+        RuntimeException e = new RuntimeException("mock send fail");
+        doThrow(e).when(sender).send(batch);
+
+        metricsQueue.addAll(batch);
+
+        boolean writerIsRunning = writer.isRunning();
+        for (int tries = 0; tries < 50 && writerIsRunning; tries++) {
+            writerIsRunning = writer.isRunning();
+            Thread.sleep(10);
+        }
+        if (writerIsRunning) {
+            fail("Writer did not stop after send failure");
+        }
+
+        assertEquals(0, metricsQueue.size());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,46 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.7.201606060606</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.32</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZING-50

Uses HTTP PUT to push push batches of metrics to the `zing-connector` service running in RM, which in turn will forward the metrics to the Zing metric-ingest service.  There are several TODOs in the code for followup work in future iterations to make the implementation more resilient and tunable.

Note that the integration is disabled by default because this feature will not be used by on-prem customers.

Here's an example of the configuration properties that must be added to the `metricService` configuration to enable this feature:
```
metricService:
    ...
    zingConfiguration:
        enabled: true
        threadPoolSize: 1
        endpoint: "http://172.17.0.1:9237/api/metrics/ingest"
```