### PR TITLE
Improvements for zing

### DIFF
--- a/metric-consumer-app/pom.xml
+++ b/metric-consumer-app/pom.xml
@@ -18,13 +18,12 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>1.17.0-rc</version>
-            <exclusions>
-                <exclusion>  <!-- declare the exclusion here -->
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>1.18.0-rc</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.6</version>
         </dependency>
         <dependency>
             <groupId>org.zenoss</groupId>

--- a/metric-consumer-app/src/main/etc/configuration.yaml
+++ b/metric-consumer-app/src/main/etc/configuration.yaml
@@ -38,7 +38,9 @@ metricService:
     #
     zingConfiguration:
         enabled: true
-        threadPoolSize: 1
+        batchSize: 100
+        threadPoolSize: 5
+        writerThreads: 5
         endpoint: "{{(getContext . "global.conf.zing-connector-url")}}/api/metrics/ingest"
 
     openTsdbClientPool:

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingSender.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingSender.java
@@ -16,6 +16,4 @@ import java.util.Collection;
 
 public interface ZingSender {
     void send(Collection<Metric> metrics) throws Exception;
-
-    void close();
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingSender.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/ZingSender.java
@@ -16,4 +16,6 @@ import java.util.Collection;
 
 public interface ZingSender {
     void send(Collection<Metric> metrics) throws Exception;
+
+    void close();
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricService.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricService.java
@@ -24,6 +24,7 @@ import org.zenoss.app.consumer.metric.MetricServiceConfiguration;
 import org.zenoss.app.consumer.metric.TsdbMetricsQueue;
 import org.zenoss.app.consumer.metric.data.Control;
 import org.zenoss.app.consumer.metric.data.Metric;
+import org.zenoss.app.consumer.metric.zing.ZingQueue;
 
 import java.io.IOException;
 import java.util.List;

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingConnectorSender.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingConnectorSender.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -71,7 +71,7 @@ public class ZingConnectorSender implements ZingSender {
 
     @Override
     public void send(Collection<Metric> metrics) throws Exception {
-        log.debug("sending {} metrics to {}", metrics.size(), configuration.getEndpoint());
+        log.trace("sending {} metrics to {}", metrics.size(), configuration.getEndpoint());
         URL url = new URL(configuration.getEndpoint());
         HttpPut request = new HttpPut(url.toURI());
         setHeaders(request);
@@ -97,10 +97,10 @@ public class ZingConnectorSender implements ZingSender {
             response = httpClient.execute(request);
             StatusLine statusLine = response.getStatusLine();
             int statusCode = statusLine.getStatusCode();
-            log.debug( "Send request complete with status: {}", statusCode);
+            log.trace( "Send request complete with status: {}", statusCode);
             if (statusCode >= 200 && statusCode <= 299) {
                 HttpEntity entity = response.getEntity();
-                log.debug("Response: {}", entity == null ? null : EntityUtils.toString(entity));
+                log.trace("Response: {}", entity == null ? null : EntityUtils.toString(entity));
             } else {
                 log.warn( "Unsuccessful response from server: {}", response.getStatusLine());
                 throw new IOException(String.format("Failed to send metrics: %s", response.getStatusLine()));

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingQueue.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingQueue.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,11 +76,11 @@ public class ZingQueue {
      * @param metrics  added elements
      * @param clientId an identifier for the remote client that is adding the metrics.
      */
-    void addAll(Collection<Metric> metrics) {
+    public void addAll(Collection<Metric> metrics) {
         queue.addAll(metrics);
     }
 
-    int size() {
+    public int size() {
         return this.queue.size();
     }
 }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriter.java
@@ -102,7 +102,6 @@ public class ZingWriter implements Runnable {
             throw e;
         } finally {
             running = false;
-            sender.close();
             writerRegistry.unregister(this);
         }
     }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriter.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,7 +158,7 @@ public class ZingWriter implements Runnable {
 
     void processBatch(Collection<Metric> metrics) {
         try {
-            log.debug("processBatch, size={}, batch={}", metrics.size(), metrics);
+            log.trace("processBatch, size={}, batch={}", metrics.size(), metrics);
             sender.send(metrics);
 
         } catch (Exception e) {

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriter.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriter.java
@@ -102,6 +102,7 @@ public class ZingWriter implements Runnable {
             throw e;
         } finally {
             running = false;
+            sender.close();
             writerRegistry.unregister(this);
         }
     }

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriterManager.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriterManager.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriterManager.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriterManager.java
@@ -39,20 +39,23 @@ public class ZingWriterManager implements Runnable  {
     private ZingConfiguration zingConfiguration = null;
     private int maxWriterThreads = 1;
     private ScheduledFuture<?> scheduledTask = null;
-    private ZingWriterRegistry writers = null;
+    private ZingWriterRegistry writerRegistry = null;
+    private ZingWriter writer = null;
 
     @Autowired
     ZingWriterManager(ApplicationContext appContext,
                       MetricServiceConfiguration config,
                       ZingQueue zingQueue,
                       ZingWriterRegistry writerRegistry,
+                      ZingWriter writer,
                       @Qualifier("zapp::executor::zing") ExecutorService executorService,
                       @Qualifier("zapp::executor::scheduled") ScheduledExecutorService scheduledExecutorService) {
         this.appContext = appContext;
         this.executorService = executorService;
         this.scheduledExecutorService = scheduledExecutorService;
         this.zingQueue = zingQueue;
-        this.writers = writerRegistry;
+        this.writerRegistry = writerRegistry;
+        this.writer = writer;
         this.zingConfiguration = config.getZingConfiguration();
         this.maxWriterThreads = zingConfiguration.getWriterThreads();
     }
@@ -80,16 +83,17 @@ public class ZingWriterManager implements Runnable  {
         int created = 0;
 
         while (needed-- > 0) {
-            ZingWriter writer = appContext.getBean(ZingWriter.class);
-            this.executorService.submit(writer);
+            // Note that this.writer is a singleton.
+            // We're creating a new thread to use this.writer, not creating a new instance of ZingWriter
+            this.executorService.submit(this.writer);
             ++created;
         }
-        logger.debug("Created {} writers", created);
+        logger.debug("Created {} writer threads", created);
     }
 
     private int needMoreWriters() {
         //
-        int current = writers.size();
+        int current = writerRegistry.size();
         int needed = 0;
 
         if (current == 0) {
@@ -101,16 +105,17 @@ public class ZingWriterManager implements Runnable  {
                 needed = 2 * current;
             }
         }
-        logger.debug("Writers needed: {}", needed);
+
+        logger.debug("Writer threads needed: {}", needed);
 
         if (needed > 0) {
             if (current >= this.maxWriterThreads) {
-                logger.debug("Current writers count exceeds allowed: {}", this.maxWriterThreads);
+                logger.debug("Current count {} exceeds max allowed: {}", current, this.maxWriterThreads);
                 needed = 0;
             } else if ((current + needed) > maxWriterThreads) {
                 needed = maxWriterThreads - current;
-                logger.debug("Current + needed writers count exceeds allowed: {}. Adjusting needed to {}",
-                        this.maxWriterThreads, needed);
+                logger.debug("Current + needed count, {}, exceeds max allowed: {}. Adjusting needed to {}",
+                        current + needed, this.maxWriterThreads, needed);
             }
         }
 

--- a/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriterRegistry.java
+++ b/metric-consumer-app/src/main/java/org/zenoss/app/consumer/metric/zing/ZingWriterRegistry.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricServiceTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/impl/OpenTsdbMetricServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.zenoss.app.consumer.metric.MetricServiceConfiguration;
 import org.zenoss.app.consumer.metric.data.Control;
 import org.zenoss.app.consumer.metric.data.Metric;
+import org.zenoss.app.consumer.metric.zing.ZingQueue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,7 +41,7 @@ public class OpenTsdbMetricServiceTest {
         metricsQueue = mock(MetricsQueue.class);
         zingQueue = mock(ZingQueue.class);
     }
-    
+
     OpenTsdbMetricService newService() {
         return new OpenTsdbMetricService(config, eventBus, metricsQueue, zingQueue);
     }
@@ -89,12 +90,12 @@ public class OpenTsdbMetricServiceTest {
         Metric metric = new Metric("name", 0, 0.0);
         ArrayList<Metric> metrics = Lists.newArrayList(metric, metric);
         config.setLowCollisionMark(1);
-        
+
         when(metricsQueue.getTotalInFlight()).thenReturn(2L);
-        
+
         OpenTsdbMetricService service = newService();
         assertEquals(Control.ok(), service.push(metrics,"test", null));
-        
+
         verify(metricsQueue, times(1)).addAll(metrics, "test");
         verify(eventBus, times(1)).post(Control.lowCollision());
     }
@@ -107,10 +108,10 @@ public class OpenTsdbMetricServiceTest {
         config.setLowCollisionMark(1);
         config.setMaxClientWaitTime(1);
         when(metricsQueue.getTotalInFlight()).thenReturn(3L);
-        
+
         OpenTsdbMetricService service = newService();
         assertEquals(Control.dropped("consumer is overwhelmed"), service.push(metricList,"test", null));
-        
+
         verify(metricsQueue, never()).addAll(metricList, "test");
         verify(eventBus, atLeastOnce()).post(Control.highCollision());
     }

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingConnectorSenderTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingConnectorSenderTest.java
@@ -11,10 +11,10 @@
 package org.zenoss.app.consumer.metric.zing;
 
 import com.google.api.client.util.Maps;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,22 +39,22 @@ public class ZingConnectorSenderTest {
 
     ZingConfiguration config;
 
-    HttpClient httpClient;
+    CloseableHttpClient httpClient;
 
-    org.zenoss.app.consumer.metric.zing.ZingConnectorSender sender;
+    ZingConnectorSender sender;
 
     @Before
     public void setUp() throws Exception {
         config = mock(ZingConfiguration.class);
         when(config.getEndpoint()).thenReturn("http://localhost:9237");
-        httpClient = mock(HttpClient.class);
+        httpClient = mock(CloseableHttpClient.class);
     }
 
     @Test
     public void testPutWorks() throws Exception {
         sender = new ZingConnectorSender(config, httpClient);
 
-        final HttpResponse response = mock(HttpResponse.class);
+        final CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 
         final StatusLine status = mock(StatusLine.class);
         when(response.getStatusLine()).thenReturn(status);
@@ -82,7 +82,7 @@ public class ZingConnectorSenderTest {
     public void testPutFailsOn400() throws Exception {
         sender = new ZingConnectorSender(config, httpClient);
 
-        final HttpResponse response = mock(HttpResponse.class);
+        final CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 
         final StatusLine status = mock(StatusLine.class);
         when(response.getStatusLine()).thenReturn(status);

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingConnectorSenderTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingConnectorSenderTest.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import com.google.api.client.util.Maps;
 import org.apache.http.HttpResponse;
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.zenoss.app.consumer.metric.ZingConfiguration;
 import org.zenoss.app.consumer.metric.data.Metric;
+import org.zenoss.app.consumer.metric.zing.ZingConnectorSender;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -40,7 +41,7 @@ public class ZingConnectorSenderTest {
 
     HttpClient httpClient;
 
-    ZingConnectorSender sender;
+    org.zenoss.app.consumer.metric.zing.ZingConnectorSender sender;
 
     @Before
     public void setUp() throws Exception {

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingWriterManagerTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingWriterManagerTest.java
@@ -35,6 +35,7 @@ public class ZingWriterManagerTest {
     MetricServiceConfiguration config;
     ZingQueue queue;
     ZingWriterRegistry registry;
+    ZingWriter writer;
     ExecutorService executorService;
     ScheduledExecutorService scheduledExecutorService;
 
@@ -44,12 +45,13 @@ public class ZingWriterManagerTest {
         config = new MetricServiceConfiguration();
         queue = mock(ZingQueue.class);
         registry = mock(ZingWriterRegistry.class);
+        writer = mock(ZingWriter.class);
         executorService = mock(ExecutorService.class);
         scheduledExecutorService = mock(ScheduledExecutorService.class);
     }
 
     ZingWriterManager createManager() {
-        return new ZingWriterManager(context, config, queue, registry, executorService, scheduledExecutorService);
+        return new ZingWriterManager(context, config, queue, registry, writer, executorService, scheduledExecutorService);
     }
 
     @Test

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingWriterManagerTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingWriterManagerTest.java
@@ -8,12 +8,16 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.zenoss.app.consumer.metric.MetricServiceConfiguration;
+import org.zenoss.app.consumer.metric.zing.ZingQueue;
+import org.zenoss.app.consumer.metric.zing.ZingWriter;
+import org.zenoss.app.consumer.metric.zing.ZingWriterManager;
+import org.zenoss.app.consumer.metric.zing.ZingWriterRegistry;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -26,7 +30,7 @@ import static org.mockito.Mockito.*;
  *
  */
 public class ZingWriterManagerTest {
- 
+
     ApplicationContext context;
     MetricServiceConfiguration config;
     ZingQueue queue;
@@ -89,7 +93,7 @@ public class ZingWriterManagerTest {
 
         manager.run();
 
-        verify(executorService, never()).submit((ZingWriter) anyObject());
+        verify(executorService, never()).submit((org.zenoss.app.consumer.metric.zing.ZingWriter) anyObject());
     }
 
     @Test

--- a/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingWriterTest.java
+++ b/metric-consumer-app/src/test/java/org/zenoss/app/consumer/metric/zing/ZingWriterTest.java
@@ -8,7 +8,7 @@
  *
  * ***************************************************************************
  */
-package org.zenoss.app.consumer.metric.impl;
+package org.zenoss.app.consumer.metric.zing;
 
 import com.google.common.collect.Lists;
 import org.junit.After;
@@ -17,6 +17,9 @@ import org.junit.Test;
 import org.zenoss.app.consumer.metric.ZingConfiguration;
 import org.zenoss.app.consumer.metric.ZingSender;
 import org.zenoss.app.consumer.metric.data.Metric;
+import org.zenoss.app.consumer.metric.zing.ZingQueue;
+import org.zenoss.app.consumer.metric.zing.ZingWriter;
+import org.zenoss.app.consumer.metric.zing.ZingWriterRegistry;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -62,7 +65,7 @@ public class ZingWriterTest {
         ZingQueue mq = mock(ZingQueue.class);
 
         configuration.setMaxIdleTime(0); // Never quit due to lack of work
-        ZingWriter writer = new ZingWriter(configuration, registry, mq, sender);
+        org.zenoss.app.consumer.metric.zing.ZingWriter writer = new ZingWriter(configuration, registry, mq, sender);
 
         Future<?> future = executor.submit(writer);
         boolean writerStarted = false;


### PR DESCRIPTION
* Fix logging problems described in [ZEN-30163](https://jira.zenoss.com/browse/ZEN-30163)
* Fix reliability problems described in [ZEN-30278](https://jira.zenoss.com/browse/ZEN-30278)

If you google the warning message described in  [ZEN-30278](https://jira.zenoss.com/browse/ZEN-30278), what you'll find is recommendation to NOT use `DefaultHttpClient` for anything but the most simple or straightforward implementations.  A more robust implementation needs to use `PoolingHttpClientConnectionManager()` - http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html#d5e627

Note that to replace `DefaultHttpClient`, I choose to upgrade `org.apache.httpcomponents` to version 4.3.6 to take advantage of the newer `HttpClients.createDefault()` method. This method encapsulates a lot of logic related to setting up a connection pool, so it seemed safer than following any of the relatively simple examples for using `PoolingHttpClientConnectionManager()`. Version 4.3.6 was the highest minor release which had `HttpClients.createDefault()`, but didn't unleash a broader wave of dependency upgrades in other parts of the dependency graph.